### PR TITLE
Fixed label of tar.gz downloads

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -100,7 +100,7 @@
 <span class="space"></span>
 <a onclick="dl('server', 'standalone');" href="https://downloads.jboss.org/keycloak/3.0.0.Final/keycloak-3.0.0.Final.tar.gz" target="_blank">
     <i class="fa fa-download" aria-hidden="true"></i>
-    ZIP
+    TAR.GZ
 </a>
 (<a href="https://downloads.jboss.org/keycloak/3.0.0.Final/keycloak-3.0.0.Final.tar.gz.md5" target="_blank">md5</a>)
         </td>
@@ -117,7 +117,7 @@
 <span class="space"></span>
 <a onclick="dl('overlay', 'standalone');" href="https://downloads.jboss.org/keycloak/3.0.0.Final/keycloak-overlay-3.0.0.Final.tar.gz" target="_blank">
     <i class="fa fa-download" aria-hidden="true"></i>
-    ZIP
+    TAR.GZ
 </a>
 (<a href="https://downloads.jboss.org/keycloak/3.0.0.Final/keycloak-overlay-3.0.0.Final.tar.gz.md5" target="_blank">md5</a>)
         </td>
@@ -134,7 +134,7 @@
 <span class="space"></span>
 <a onclick="dl('demo', 'demo');" href="https://downloads.jboss.org/keycloak/3.0.0.Final/keycloak-demo-3.0.0.Final.tar.gz" target="_blank">
     <i class="fa fa-download" aria-hidden="true"></i>
-    ZIP
+    TAR.GZ
 </a>
 (<a href="https://downloads.jboss.org/keycloak/3.0.0.Final/keycloak-demo-3.0.0.Final.tar.gz.md5" target="_blank">md5</a>)
         </td>
@@ -206,7 +206,7 @@
 <span class="space"></span>
 <a onclick="dl('adapter', 'wildfly');" href="https://downloads.jboss.org/keycloak/3.0.0.Final/adapters/keycloak-oidc/keycloak-wildfly-adapter-dist-3.0.0.Final.tar.gz" target="_blank">
     <i class="fa fa-download" aria-hidden="true"></i>
-    ZIP
+    TAR.GZ
 </a>
 (<a href="https://downloads.jboss.org/keycloak/3.0.0.Final/adapters/keycloak-oidc/keycloak-wildfly-adapter-dist-3.0.0.Final.tar.gz.md5" target="_blank">md5</a>)
                                 </td>
@@ -261,7 +261,7 @@
 <span class="space"></span>
 <a onclick="dl('adapter', 'eap6');" href="https://downloads.jboss.org/keycloak/3.0.0.Final/adapters/keycloak-oidc/keycloak-eap6-adapter-dist-3.0.0.Final.tar.gz" target="_blank">
     <i class="fa fa-download" aria-hidden="true"></i>
-    ZIP
+    TAR.GZ
 </a>
 (<a href="https://downloads.jboss.org/keycloak/3.0.0.Final/adapters/keycloak-oidc/keycloak-eap6-adapter-dist-3.0.0.Final.tar.gz.md5" target="_blank">md5</a>)
                                 </td>
@@ -307,7 +307,7 @@
 <span class="space"></span>
 <a onclick="dl('adapter', 'fuse');" href="https://downloads.jboss.org/keycloak/3.0.0.Final/adapters/keycloak-oidc/keycloak-fuse-adapter-dist-3.0.0.Final.tar.gz" target="_blank">
     <i class="fa fa-download" aria-hidden="true"></i>
-    ZIP
+    TAR.GZ
 </a>
 (<a href="https://downloads.jboss.org/keycloak/3.0.0.Final/adapters/keycloak-oidc/keycloak-fuse-adapter-dist-3.0.0.Final.tar.gz.md5" target="_blank">md5</a>)
                                 </td>
@@ -330,7 +330,7 @@
 <span class="space"></span>
 <a onclick="dl('adapter', 'js');" href="https://downloads.jboss.org/keycloak/3.0.0.Final/adapters/keycloak-oidc/keycloak-js-adapter-dist-3.0.0.Final.tar.gz" target="_blank">
     <i class="fa fa-download" aria-hidden="true"></i>
-    ZIP
+    TAR.GZ
 </a>
 (<a href="https://downloads.jboss.org/keycloak/3.0.0.Final/adapters/keycloak-oidc/keycloak-js-adapter-dist-3.0.0.Final.tar.gz.md5" target="_blank">md5</a>)
                                 </td>
@@ -353,7 +353,7 @@
 <span class="space"></span>
 <a onclick="dl('adapter', 'jetty9.4');" href="https://downloads.jboss.org/keycloak/3.0.0.Final/adapters/keycloak-oidc/keycloak-jetty94-adapter-dist-3.0.0.Final.tar.gz" target="_blank">
     <i class="fa fa-download" aria-hidden="true"></i>
-    ZIP
+    TAR.GZ
 </a>
 (<a href="https://downloads.jboss.org/keycloak/3.0.0.Final/adapters/keycloak-oidc/keycloak-jetty94-adapter-dist-3.0.0.Final.tar.gz.md5" target="_blank">md5</a>)
                                 </td>
@@ -369,7 +369,7 @@
 <span class="space"></span>
 <a onclick="dl('adapter', 'jetty9.3');" href="https://downloads.jboss.org/keycloak/3.0.0.Final/adapters/keycloak-oidc/keycloak-jetty93-adapter-dist-3.0.0.Final.tar.gz" target="_blank">
     <i class="fa fa-download" aria-hidden="true"></i>
-    ZIP
+    TAR.GZ
 </a>
 (<a href="https://downloads.jboss.org/keycloak/3.0.0.Final/adapters/keycloak-oidc/keycloak-jetty93-adapter-dist-3.0.0.Final.tar.gz.md5" target="_blank">md5</a>)
                                 </td>
@@ -385,7 +385,7 @@
 <span class="space"></span>
 <a onclick="dl('adapter', 'jetty9.2');" href="https://downloads.jboss.org/keycloak/3.0.0.Final/adapters/keycloak-oidc/keycloak-jetty92-adapter-dist-3.0.0.Final.tar.gz" target="_blank">
     <i class="fa fa-download" aria-hidden="true"></i>
-    ZIP
+    TAR.GZ
 </a>
 (<a href="https://downloads.jboss.org/keycloak/3.0.0.Final/adapters/keycloak-oidc/keycloak-jetty92-adapter-dist-3.0.0.Final.tar.gz.md5" target="_blank">md5</a>)
                                 </td>
@@ -401,7 +401,7 @@
 <span class="space"></span>
 <a onclick="dl('adapter', 'jetty9.1');" href="https://downloads.jboss.org/keycloak/3.0.0.Final/adapters/keycloak-oidc/keycloak-jetty91-adapter-dist-3.0.0.Final.tar.gz" target="_blank">
     <i class="fa fa-download" aria-hidden="true"></i>
-    ZIP
+    TAR.GZ
 </a>
 (<a href="https://downloads.jboss.org/keycloak/3.0.0.Final/adapters/keycloak-oidc/keycloak-jetty91-adapter-dist-3.0.0.Final.tar.gz.md5" target="_blank">md5</a>)
                                 </td>
@@ -417,7 +417,7 @@
 <span class="space"></span>
 <a onclick="dl('adapter', 'jetty8.1');" href="https://downloads.jboss.org/keycloak/3.0.0.Final/adapters/keycloak-oidc/keycloak-jetty81-adapter-dist-3.0.0.Final.tar.gz" target="_blank">
     <i class="fa fa-download" aria-hidden="true"></i>
-    ZIP
+    TAR.GZ
 </a>
 (<a href="https://downloads.jboss.org/keycloak/3.0.0.Final/adapters/keycloak-oidc/keycloak-jetty81-adapter-dist-3.0.0.Final.tar.gz.md5" target="_blank">md5</a>)
                                 </td>
@@ -440,7 +440,7 @@
 <span class="space"></span>
 <a onclick="dl('adapter', 'tomcat8');" href="https://downloads.jboss.org/keycloak/3.0.0.Final/adapters/keycloak-oidc/keycloak-tomcat8-adapter-dist-3.0.0.Final.tar.gz" target="_blank">
     <i class="fa fa-download" aria-hidden="true"></i>
-    ZIP
+    TAR.GZ
 </a>
 (<a href="https://downloads.jboss.org/keycloak/3.0.0.Final/adapters/keycloak-oidc/keycloak-tomcat8-adapter-dist-3.0.0.Final.tar.gz.md5" target="_blank">md5</a>)
                                 </td>
@@ -456,7 +456,7 @@
 <span class="space"></span>
 <a onclick="dl('adapter', 'tomcat7');" href="https://downloads.jboss.org/keycloak/3.0.0.Final/adapters/keycloak-oidc/keycloak-tomcat7-adapter-dist-3.0.0.Final.tar.gz" target="_blank">
     <i class="fa fa-download" aria-hidden="true"></i>
-    ZIP
+    TAR.GZ
 </a>
 (<a href="https://downloads.jboss.org/keycloak/3.0.0.Final/adapters/keycloak-oidc/keycloak-tomcat7-adapter-dist-3.0.0.Final.tar.gz.md5" target="_blank">md5</a>)
                                 </td>
@@ -472,7 +472,7 @@
 <span class="space"></span>
 <a onclick="dl('adapter', 'tomcat6');" href="https://downloads.jboss.org/keycloak/3.0.0.Final/adapters/keycloak-oidc/keycloak-tomcat6-adapter-dist-3.0.0.Final.tar.gz" target="_blank">
     <i class="fa fa-download" aria-hidden="true"></i>
-    ZIP
+    TAR.GZ
 </a>
 (<a href="https://downloads.jboss.org/keycloak/3.0.0.Final/adapters/keycloak-oidc/keycloak-tomcat6-adapter-dist-3.0.0.Final.tar.gz.md5" target="_blank">md5</a>)
                                 </td>
@@ -502,7 +502,7 @@
 <span class="space"></span>
 <a onclick="dl('adapter-saml', 'wildfly');" href="https://downloads.jboss.org/keycloak/3.0.0.Final/adapters/saml/keycloak-saml-wildfly-adapter-dist-3.0.0.Final.tar.gz" target="_blank">
     <i class="fa fa-download" aria-hidden="true"></i>
-    ZIP
+    TAR.GZ
 </a>
 (<a href="https://downloads.jboss.org/keycloak/3.0.0.Final/adapters/saml/keycloak-saml-wildfly-adapter-dist-3.0.0.Final.tar.gz.md5" target="_blank">md5</a>)
                                 </td>
@@ -525,7 +525,7 @@
 <span class="space"></span>
 <a onclick="dl('adapter-saml', 'eap7');" href="https://downloads.jboss.org/keycloak/3.0.0.Final/adapters/saml/keycloak-saml-wildfly-adapter-dist-3.0.0.Final.tar.gz" target="_blank">
     <i class="fa fa-download" aria-hidden="true"></i>
-    ZIP
+    TAR.GZ
 </a>
 (<a href="https://downloads.jboss.org/keycloak/3.0.0.Final/adapters/saml/keycloak-saml-wildfly-adapter-dist-3.0.0.Final.tar.gz.md5" target="_blank">md5</a>)
                                 </td>
@@ -541,7 +541,7 @@
 <span class="space"></span>
 <a onclick="dl('adapter-saml', 'eap6');" href="https://downloads.jboss.org/keycloak/3.0.0.Final/adapters/saml/keycloak-saml-eap6-adapter-dist-3.0.0.Final.tar.gz" target="_blank">
     <i class="fa fa-download" aria-hidden="true"></i>
-    ZIP
+    TAR.GZ
 </a>
 (<a href="https://downloads.jboss.org/keycloak/3.0.0.Final/adapters/saml/keycloak-saml-eap6-adapter-dist-3.0.0.Final.tar.gz.md5" target="_blank">md5</a>)
                                 </td>
@@ -564,7 +564,7 @@
 <span class="space"></span>
 <a onclick="dl('adapter-saml', 'as7');" href="https://downloads.jboss.org/keycloak/3.0.0.Final/adapters/saml/keycloak-saml-as7-adapter-dist-3.0.0.Final.tar.gz" target="_blank">
     <i class="fa fa-download" aria-hidden="true"></i>
-    ZIP
+    TAR.GZ
 </a>
 (<a href="https://downloads.jboss.org/keycloak/3.0.0.Final/adapters/saml/keycloak-saml-as7-adapter-dist-3.0.0.Final.tar.gz.md5" target="_blank">md5</a>)
                                 </td>
@@ -587,7 +587,7 @@
 <span class="space"></span>
 <a onclick="dl('adapter-saml', 'jetty9.4');" href="https://downloads.jboss.org/keycloak/3.0.0.Final/adapters/saml/keycloak-saml-jetty94-adapter-dist-3.0.0.Final.tar.gz" target="_blank">
     <i class="fa fa-download" aria-hidden="true"></i>
-    ZIP
+    TAR.GZ
 </a>
 (<a href="https://downloads.jboss.org/keycloak/3.0.0.Final/adapters/saml/keycloak-saml-jetty94-adapter-dist-3.0.0.Final.tar.gz.md5" target="_blank">md5</a>)
                                 </td>
@@ -603,7 +603,7 @@
 <span class="space"></span>
 <a onclick="dl('adapter-saml', 'jetty9.3');" href="https://downloads.jboss.org/keycloak/3.0.0.Final/adapters/saml/keycloak-saml-jetty93-adapter-dist-3.0.0.Final.tar.gz" target="_blank">
     <i class="fa fa-download" aria-hidden="true"></i>
-    ZIP
+    TAR.GZ
 </a>
 (<a href="https://downloads.jboss.org/keycloak/3.0.0.Final/adapters/saml/keycloak-saml-jetty93-adapter-dist-3.0.0.Final.tar.gz.md5" target="_blank">md5</a>)
                                 </td>
@@ -619,7 +619,7 @@
 <span class="space"></span>
 <a onclick="dl('adapter-saml', 'jetty9.2');" href="https://downloads.jboss.org/keycloak/3.0.0.Final/adapters/saml/keycloak-saml-jetty92-adapter-dist-3.0.0.Final.tar.gz" target="_blank">
     <i class="fa fa-download" aria-hidden="true"></i>
-    ZIP
+    TAR.GZ
 </a>
 (<a href="https://downloads.jboss.org/keycloak/3.0.0.Final/adapters/saml/keycloak-saml-jetty92-adapter-dist-3.0.0.Final.tar.gz.md5" target="_blank">md5</a>)
                                 </td>
@@ -635,7 +635,7 @@
 <span class="space"></span>
 <a onclick="dl('adapter-saml', 'jetty8.1');" href="https://downloads.jboss.org/keycloak/3.0.0.Final/adapters/saml/keycloak-saml-jetty81-adapter-dist-3.0.0.Final.tar.gz" target="_blank">
     <i class="fa fa-download" aria-hidden="true"></i>
-    ZIP
+    TAR.GZ
 </a>
 (<a href="https://downloads.jboss.org/keycloak/3.0.0.Final/adapters/saml/keycloak-saml-jetty81-adapter-dist-3.0.0.Final.tar.gz.md5" target="_blank">md5</a>)
                                 </td>
@@ -658,7 +658,7 @@
 <span class="space"></span>
 <a onclick="dl('adapter-saml', 'tomcat8');" href="https://downloads.jboss.org/keycloak/3.0.0.Final/adapters/saml/keycloak-saml-tomcat8-adapter-dist-3.0.0.Final.tar.gz" target="_blank">
     <i class="fa fa-download" aria-hidden="true"></i>
-    ZIP
+    TAR.GZ
 </a>
 (<a href="https://downloads.jboss.org/keycloak/3.0.0.Final/adapters/saml/keycloak-saml-tomcat8-adapter-dist-3.0.0.Final.tar.gz.md5" target="_blank">md5</a>)
                                 </td>
@@ -674,7 +674,7 @@
 <span class="space"></span>
 <a onclick="dl('adapter-saml', 'tomcat7');" href="https://downloads.jboss.org/keycloak/3.0.0.Final/adapters/saml/keycloak-saml-tomcat7-adapter-dist-3.0.0.Final.tar.gz" target="_blank">
     <i class="fa fa-download" aria-hidden="true"></i>
-    ZIP
+    TAR.GZ
 </a>
 (<a href="https://downloads.jboss.org/keycloak/3.0.0.Final/adapters/saml/keycloak-saml-tomcat7-adapter-dist-3.0.0.Final.tar.gz.md5" target="_blank">md5</a>)
                                 </td>
@@ -690,7 +690,7 @@
 <span class="space"></span>
 <a onclick="dl('adapter-saml', 'tomcat6');" href="https://downloads.jboss.org/keycloak/3.0.0.Final/adapters/saml/keycloak-saml-tomcat6-adapter-dist-3.0.0.Final.tar.gz" target="_blank">
     <i class="fa fa-download" aria-hidden="true"></i>
-    ZIP
+    TAR.GZ
 </a>
 (<a href="https://downloads.jboss.org/keycloak/3.0.0.Final/adapters/saml/keycloak-saml-tomcat6-adapter-dist-3.0.0.Final.tar.gz.md5" target="_blank">md5</a>)
                                 </td>


### PR DESCRIPTION
The labels on the download page are incorrect. Both a`.zip` and `.tar.gz` are named `ZIP`. ;-)