### PR TITLE
Included embedded DB vendor

### DIFF
--- a/getting-started/getting-started-docker.html
+++ b/getting-started/getting-started-docker.html
@@ -74,7 +74,7 @@
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight"><code class="language-bash" data-lang="bash">docker run -p 8080:8080 -e KEYCLOAK_USER=admin -e KEYCLOAK_PASSWORD=admin quay.io/keycloak/keycloak:15.0.2</code></pre>
+<pre class="highlight"><code class="language-bash" data-lang="bash">docker run -p 8080:8080 -e KEYCLOAK_USER=admin -e KEYCLOAK_PASSWORD=admin -e DB_VENDOR=h2 quay.io/keycloak/keycloak:15.0.2</code></pre>
 </div>
 </div>
 <div class="paragraph">


### PR DESCRIPTION
Without the embedded DB vendor in the environment variables, the container will fail to start as it expects a connection to a Postgres database. For testing, it is essential to include this variable.