### PR TITLE
Fixes links on https://www.keycloak.org/

### DIFF
--- a/2017/03/how-to-setup-ms-ad-fs-30-as-brokered.html
+++ b/2017/03/how-to-setup-ms-ad-fs-30-as-brokered.html
@@ -99,7 +99,7 @@
 <b id="docs-internal-guid-d7a78233-f66d-5bde-d887-549caec7811b" style="font-weight: normal;"><br /></b>
 <br />
 <div style="margin-bottom: 0pt; margin-top: 0pt; text-align: center;">
-<span><img height="640" src="https://www.keycloak.org//resources/images/blog/adfs/0-adfs.png" width="617" /></span></div>
+<span><img height="640" src="https://www.keycloak.org/resources/images/blog/adfs/0-adfs.png" width="617" /></span></div>
 <h3 style="margin-bottom: 4pt; margin-top: 16pt;">
 <span style="color: #434343; font-size: 14pt; white-space: pre-wrap;">Setup Mappers</span></h3>
 <p><span>In the steps setting AD FS below, AD FS will be set up to send email and group information in SAML assertion. To transform these details from SAML document issued by AD FS to Keycloak user store, we’ll need to set up two corresponding mappers in the Mappers tab of Identity Provider:</span></p>
@@ -108,13 +108,13 @@
 </ul>
 <p><span><span class="Apple-tab-span" style="white-space: pre;"> </span></span></p>
 <div style="margin-bottom: 0pt; margin-top: 0pt; text-align: center;">
-<span><span class="Apple-tab-span" style="white-space: pre;"> </span></span><span><img height="266" src="https://www.keycloak.org//resources/images/blog/adfs/1-adfs.png" width="400" /></span></div>
+<span><span class="Apple-tab-span" style="white-space: pre;"> </span></span><span><img height="266" src="https://www.keycloak.org/resources/images/blog/adfs/1-adfs.png" width="400" /></span></div>
 <br />
 <ul>
 <li>Mapper named </span><span style="font-size: 11pt; font-style: italic">Attribute: email</span><span> will be of type </span><span style="font-size: 11pt; font-style: italic">Attribute Importer</span><span>, and will map attribute named </span><span style="font-size: 11pt; font-style: italic">http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress</span><span> into user attribute named </span><span style="font-size: 11pt; font-style: italic">email</span><span>.</li>
 </ul>
 <div style="margin-bottom: 0pt; margin-top: 0pt; text-align: center;">
-<span><img height="200" src="https://www.keycloak.org//resources/images/blog/adfs/2-adfs.png" width="400" /></span></div>
+<span><img height="200" src="https://www.keycloak.org/resources/images/blog/adfs/2-adfs.png" width="400" /></span></div>
 <h3 style="margin-bottom: 4pt; margin-top: 16pt;">
 <span style="color: #434343; font-size: 14pt; white-space: pre-wrap;">Obtain information for the AD FS configuration</span></h3>
 <p><span>Now we determine SAML service provider descriptor URI that will be used in AD FS setup from the </span><span style="font-size: 11pt; font-style: italic">Redirect URI</span><span> field in the identity provider detail by adding “/descriptor” to the URI in this field. The URI will be similar to </span><span style="font-weight: 700">https://kc.domain.name:8443/auth/realms/master/broker/adfs-idp-alias/endpoint/descriptor</span><span>. You can check whether you got the URI right by entering the URI into the browser - you should receive a SAML service provider XML descriptor.</span></p>
@@ -125,7 +125,7 @@
 <p><span>In AD FS Management console, right-click Tr</span><span style="font-size: 11pt; font-style: italic">ust relationships → Relying Party Trusts</span><span> and select </span><span style="font-size: 11pt; font-style: italic">Add Relying Party Trust</span><span> from the menu:</span></p>
 <br />
 <div style="margin-bottom: 0pt; margin-top: 0pt; text-align: center;">
-<span><img src="https://www.keycloak.org//resources/images/blog/adfs/3-adfs.png" /></span></div>
+<span><img src="https://www.keycloak.org/resources/images/blog/adfs/3-adfs.png" /></span></div>
 <br />
 <p><span>At the beginning of the wizard, enter the SAML descriptor URL obtained in the previous step into the </span><span style="font-size: 11pt; font-style: italic">Federation metadata address </span><span>field, and let AD FS import the settings. Proceed with the wizard, and adjust the settings where appropriate. Here we use only the default settings. Note that you will need to edit the claim rules so when asked to do so at the last page of the wizard, you can leave the checkbox checked on.</span></p>
 <h4 style="margin-bottom: 4pt; margin-top: 14pt;">
@@ -134,24 +134,24 @@
 <p><span>We will set up three rules: one for mapping user ID, second for mapping standard user attributes, and third for a user group. All start by clicking the </span><span style="font-size: 11pt; font-style: italic">Add Rule</span><span> button in the </span><span style="font-size: 11pt; font-style: italic">Edit Claim Rules for kc.domain.name</span><span> window:</span></p>
 <br />
 <div style="margin-bottom: 0pt; margin-top: 0pt; text-align: center;">
-<span><img height="400" src="https://www.keycloak.org//resources/images/blog/adfs/4-adfs.png" width="365" /></span></div>
+<span><img height="400" src="https://www.keycloak.org/resources/images/blog/adfs/4-adfs.png" width="365" /></span></div>
 <br />
 <p><span>The first rule will map user ID in Windows Qualified Domain name to the SAML response. In the </span><span style="font-size: 11pt; font-style: italic">Add Transform Claim Rule</span><span> window, select </span><span style="font-size: 11pt; font-style: italic">Transform an incoming claim </span><span>rule type:</span></p>
 <br />
 <div style="margin-bottom: 0pt; margin-top: 0pt; text-align: center;">
-<span><img height="515" src="https://www.keycloak.org//resources/images/blog/adfs/5-adfs.png" width="640" /></span></div>
+<span><img height="515" src="https://www.keycloak.org/resources/images/blog/adfs/5-adfs.png" width="640" /></span></div>
 <br />
 <p><span>The example above targets windows account name ID format. Other name ID formats are supported but out of scope of this post. See e.g. <a href="https://blogs.msdn.microsoft.com/card/2010/02/17/name-identifiers-in-saml-assertions/">this blog</a> on how to setup name IDs for persistent and transient formats.</span></p>
 <br />
 <p><span>The second rule will map user e-mail to the SAML response. In the </span><span style="font-size: 11pt; font-style: italic">Add Transform Claim Rule</span><span> window, select </span><span style="font-size: 11pt; font-style: italic">Send LDAP attributes as Claims </span><span>rule type. You can add other attributes as needed:</span></p>
 <br />
 <div style="margin-bottom: 0pt; margin-top: 0pt; text-align: center;">
-<span><img src="https://www.keycloak.org//resources/images/blog/adfs/6-adfs.png" /></span></div>
+<span><img src="https://www.keycloak.org/resources/images/blog/adfs/6-adfs.png" /></span></div>
 <br />
 <p><span>The third rule would send a group name if the user is member of a named group. Start again in the </span><span style="font-size: 11pt; font-style: italic">Add Transform Claim Rule</span><span> window, and select </span><span style="font-size: 11pt; font-style: italic">Send Group Membership as a Claim </span><span>rule type. Then enter the requested values in the field:</span></p>
 <br />
 <div style="margin-bottom: 0pt; margin-top: 0pt; text-align: center;">
-<span><img height="515" src="https://www.keycloak.org//resources/images/blog/adfs/7-adfs.png" width="640" /></span></div>
+<span><img height="515" src="https://www.keycloak.org/resources/images/blog/adfs/7-adfs.png" width="640" /></span></div>
 <br />
 <p><span>This setup would send an attribute named </span><span style="font-size: 11pt; font-style: italic">Group </span><span>in the SAML assertion with value </span><span style="font-size: 11pt; font-style: italic">managers</span><span> if the authenticated user is member of the </span><span style="font-size: 11pt; font-style: italic">DOMAIN\Managers</span><span> group.</span></p>
 <h2>

--- a/2018/02/keycloak-and-angular-cli.html
+++ b/2018/02/keycloak-and-angular-cli.html
@@ -84,7 +84,7 @@ ng generate keycloak --collection @ssilvert/keycloak-schematic --clientId=myApp
 
 <p>Go to your browser to start the app and see this:</p>
 
-<img src="https://www.keycloak.org//resources/images/blog/login.png"/>
+<img src="https://www.keycloak.org/resources/images/blog/login.png"/>
 
 <p>Oh joy! myApp is protected with Keycloak!</p>
 

--- a/2018/02/keycloak-and-istio.html
+++ b/2018/02/keycloak-and-istio.html
@@ -83,13 +83,13 @@
 
 <p>Envoy captures all incoming and outgoing traffic of its "companion" service, it can then apply some basic operations and also collect data and send it to a central point of decision, called the "mixer" in Istio. The conifugration of Envoy itself happens through the "pilot" an other Istio component.</p>
 
-<img src="https://www.keycloak.org//resources/images/blog/istio-architecture.png"/><div>
+<img src="https://www.keycloak.org/resources/images/blog/istio-architecture.png"/><div>
 
 <h3>Envoy Filters</h3>
 
 <p>To make it easier to add new functionnality to the Envoy Proxy, there is the concept of filters that you can stack up. Again, these filters can be congifured by the Pilot and they can gather information for the Mixer:</p>
 
-<img src="https://www.keycloak.org//resources/images/blog/envoydetails.png" />
+<img src="https://www.keycloak.org/resources/images/blog/envoydetails.png" />
 
 <h3>The JWT-Auth Filter</h3>
 
@@ -101,7 +101,7 @@
 
 <p>Now that you have the big picture in mind let's take a look at the demo that has been developed by Kamesh Sampath (@kamesh_sampath) From the Red Hat Developer Experience Team to show how Keycloak and Istio can be combined:</p>
 
-<img src="https://www.keycloak.org//resources/images/blog/bigpicure1.png"/>
+<img src="https://www.keycloak.org/resources/images/blog/bigpicure1.png"/>
 
 <p>The demo will be running inside a Minishift instance, Minishift is a tool that helps to run OpenShift locally. Minishift has really nice support for Istio, as it takes only a few commands to install the Istio layer inside a Minishift instance.</p>
 
@@ -126,7 +126,7 @@
 
 <p>Thi is how the Cars API Pod looks like after it is deployed:</p>
 
-<img src="https://www.keycloak.org//resources/images/blog/carsapipod.png" />
+<img src="https://www.keycloak.org/resources/images/blog/carsapipod.png" />
 
 <p>Now, the Envoy Sidecar needs to be configured:</p>
 
@@ -136,7 +136,7 @@
 <li>The issuer : who has generated the token ? In this case it's also the Keycloak Server.</li>
 </ul>
 
-<img src="https://www.keycloak.org//resources/images/blog/pilotscript.png" />
+<img src="https://www.keycloak.org/resources/images/blog/pilotscript.png" />
 
 <p>Now each incoming request to the API Service will be checked by the Envoy Sidecar to see if the JWT token contained in the header is valid or not. If it's valid the request be authorized otherwise an error message will be returned.</p>
 

--- a/2018/06/red-hat-single-sign-on-in-keynote-demo.html
+++ b/2018/06/red-hat-single-sign-on-in-keynote-demo.html
@@ -76,7 +76,7 @@
 
 <p>With Javascript application, whole OpenID Connect login flow happens within browser and hence can rely on sticky session. So since Javascript adapter is used, you may think that we can do just "easy" setup and let the RH-SSO instances across all 3 clouds to be independent of each other and have each of them to use separate RDBMS and infinispan caches. See the image below  for what such a setup would look like:
 
-<img src="https://www.keycloak.org//resources/images/blog/cross-dc-blog-architecture-rhsso.png" />
+<img src="https://www.keycloak.org/resources/images/blog/cross-dc-blog-architecture-rhsso.png" />
 
 <p>With this setup, every cloud is aware just about the users and sessions created on itself. This is fine with sticky session, but it won’t work for failover scenarios in case if one of the 3 clouds is broken/removed. There are also other issues with it - for example that admins and users see just sessions created on particular cloud. There are also potential security issues. For example when admin disables user on one cloud, user would still be enabled on other clouds as changes to user won’t be propagated to other clouds.
 
@@ -84,7 +84,7 @@
 
 <p>In Keycloak 3.X, we added support for <a href="https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.2/html/server_installation_and_configuration_guide/operating-mode#crossdc-mode">Cross-datacenter (Cross-site) setup</a> with usage of external JDG servers to replicate data among datacenters (tech preview in RH-SSO 7.2). The demo was using exactly this setup. Each site had JDG server and all 3 sites communicate with each other through those JDG servers. This is standard JDG Cross-DC setup. See the picture below for what the demo looked like:
 
-<img src="https://www.keycloak.org//resources/images/blog/cross-dc-blog-actual-setup-architecture-rhsso.png" />
+<img src="https://www.keycloak.org/resources/images/blog/cross-dc-blog-actual-setup-architecture-rhsso.png" />
 
 <p>The JDG servers were not used during the demo just for the purpose of the RH-SSO, but also for the purpose of other parts of the demo. The details are described in the <a href="https://developers.redhat.com/blog/2018/06/19/red-hat-data-grid-on-three-clouds/">JDG setup blog by  Sebastian Łaskawiec</a>. The JDG servers were setup with ASYNC backups, which was more effective and was completely fine for the purpose of the demo due the fact that mobile application was using keycloak.js adapter. See <a href="https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.2/html/server_installation_and_configuration_guide/operating-mode#backups">RH-SSO docs</a> for more details.
 
@@ -104,7 +104,7 @@
 
 <p>For the purpose of the demo, we did custom login theme. We also did Email-Only authenticator, which allows to register user just by providing their email address. This is obviously not very secure, but it's pretty neat for the example purpose. Keynote users were also able to login with <a href="https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.2/html/server_administration_guide/identity_broker#google">Google Identity Provider</a>  or <a href="https://developers.redhat.com/">Red Hat Developers OpenID Connect Identity Provider</a>, which was useful for users, who already had an account in those services.
 
-<img src="https://www.keycloak.org//resources/images/blog/login-screen.png" />
+<img src="https://www.keycloak.org/resources/images/blog/login-screen.png" />
 
 <p>If you want to try all these things in action, you can try to checkout our <a href="https://github.com/rhdemo/rh-sso">Demo Project on Github</a> and deploy it to your own openshift cluster! If you have 3 clouds, even better! You can try the full setup including JDG to try exactly the setup we used during keynote demo.
 

--- a/2019/05/keycloak-cluster-setup.html
+++ b/2019/05/keycloak-cluster-setup.html
@@ -84,14 +84,14 @@ ADD cli/JDBC_PING.cli /opt/jboss/tools/cli/jgroups/discovery/
 <h3>1. PING</h3>
 <p><a href="http://jgroups.org/manual/#PING">PING</a> is the default enabled clustering solution of Keycloak using UDP protocol, and you don't need to do any configuration for this.</p>
 <p>But PING is only available when multicast network is enabled and port 55200 should be exposed, e.g. bare metals, VMs, docker containers in the same host.</p>
-<img src="https://www.keycloak.org//resources/images/blog/cluster-setup/ping-deployment.jpg"/>
+<img src="https://www.keycloak.org/resources/images/blog/cluster-setup/ping-deployment.jpg"/>
 <p>We tested this by two Keycloak containers in same host.</p>
 <p>The logs show that the two Keycloak instances discovered each other and clustered.</p>
-<img src="https://www.keycloak.org//resources/images/blog/cluster-setup/ping-log.png"/>
+<img src="https://www.keycloak.org/resources/images/blog/cluster-setup/ping-log.png"/>
 
 <h3>2. TCPPING</h3>
 <p><a href="http://jgroups.org/manual/#TCPPING_Prot">TCPPING</a> use TCP protocol with 7600 port. This can be used when multicast is not available, e.g. deployments cross DC, containers cross host.</p>
-<img src="https://www.keycloak.org//resources/images/blog/cluster-setup/tcp-ping-deployment.jpg"/>
+<img src="https://www.keycloak.org/resources/images/blog/cluster-setup/tcp-ping-deployment.jpg"/>
 <p>We tested this by two Keycloak containers cross host.</p>
 <p>And in this solution we need to set three below environment variables for containers.
 <pre>
@@ -104,7 +104,7 @@ JGROUPS_DISCOVERY_PROPERTIES=initial_hosts="172.21.48.4[7600],172.21.48.39[7600]
 </pre>
 </p>
 <p>The logs show that the two Keycloak instances discovered each other and clustered.</p>
-<img src="https://www.keycloak.org//resources/images/blog/cluster-setup/tcp-ping-log.png"/>
+<img src="https://www.keycloak.org/resources/images/blog/cluster-setup/tcp-ping-log.png"/>
 
 <h3>3. JDBC_PING</h3>
 <p><a href="http://jgroups.org/manual/#_jdbc_ping">JDBC_PING</a> use TCP protocol with 7600 port which is similar as TCPPING, but the difference between them is, TCPPING requires you configure the IP and port of all instances,  for JDBC_PING you just need to configure the IP and port of current instance, this is because in JDBC_PING solution each instance insert its own information into database and the instances discover peers by the ping data read from database.</p>
@@ -118,9 +118,9 @@ JGROUPS_DISCOVERY_PROTOCOL=JDBC_PING
 </pre>
 </p>
 <p>The ping data of all instances haven been saved in database after instances started.</p>
-<img src="https://www.keycloak.org//resources/images/blog/cluster-setup/jdbc-ping-data.png"/>
+<img src="https://www.keycloak.org/resources/images/blog/cluster-setup/jdbc-ping-data.png"/>
 <p>The logs show that the two Keycloak instances discovered each other and clustered.</p>
-<img src="https://www.keycloak.org//resources/images/blog/cluster-setup/jdbc-ping-log.png"/>
+<img src="https://www.keycloak.org/resources/images/blog/cluster-setup/jdbc-ping-log.png"/>
 
 <h3>One more thing</h3>
 <p>The above solutions are available for most scenarios, but they are still not enough for some others, e.g.Kubernetes.</p>

--- a/2020/02/keycloak-900-released.html
+++ b/2020/02/keycloak-900-released.html
@@ -122,7 +122,7 @@ Thanks to <a href="https://github.com/tnorimat">tnorimat</a></p>
 </div>
 </div>
 <h2>All resolved issues</h2>
-<p>The full list of resolved issues are available in <a href="https://github.com/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A9.0.0">GitHub Issues</a></p>
+<p>The full list of resolved issues are available in <a href="https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A9.0.0">GitHub Issues</a></p>
 
 <h2>Upgrading</h2>
 <p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org//docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>

--- a/2020/02/keycloak-900-released.html
+++ b/2020/02/keycloak-900-released.html
@@ -61,7 +61,7 @@
         This post is more than one year old. The contents within the blog is likely to be out of date.
         </div>
 
-<p>To download the release go to <a href="https://www.keycloak.org//downloads.html">Keycloak downloads</a>.</p>
+<p>To download the release go to <a href="https://www.keycloak.org/downloads.html">Keycloak downloads</a>.</p>
 
 <div class="sect1">
 <h2 id="_highlights">Highlights</h2>
@@ -125,7 +125,7 @@ Thanks to <a href="https://github.com/tnorimat">tnorimat</a></p>
 <p>The full list of resolved issues are available in <a href="https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A9.0.0">GitHub Issues</a></p>
 
 <h2>Upgrading</h2>
-<p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org//docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>
+<p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org/docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>
     </div>
 </div>
 		</div>

--- a/2020/03/keycloak-902-released.html
+++ b/2020/03/keycloak-902-released.html
@@ -61,14 +61,14 @@
         This post is more than one year old. The contents within the blog is likely to be out of date.
         </div>
 
-<p>To download the release go to <a href="https://www.keycloak.org//downloads.html">Keycloak downloads</a>.</p>
+<p>To download the release go to <a href="https://www.keycloak.org/downloads.html">Keycloak downloads</a>.</p>
 
 
 <h2>All resolved issues</h2>
 <p>The full list of resolved issues are available in <a href="https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A9.0.2">GitHub Issues</a></p>
 
 <h2>Upgrading</h2>
-<p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org//docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>
+<p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org/docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>
     </div>
 </div>
 		</div>

--- a/2020/03/keycloak-902-released.html
+++ b/2020/03/keycloak-902-released.html
@@ -65,7 +65,7 @@
 
 
 <h2>All resolved issues</h2>
-<p>The full list of resolved issues are available in <a href="https://github.com/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A9.0.2">GitHub Issues</a></p>
+<p>The full list of resolved issues are available in <a href="https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A9.0.2">GitHub Issues</a></p>
 
 <h2>Upgrading</h2>
 <p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org//docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>

--- a/2020/04/keycloak-1000-released.html
+++ b/2020/04/keycloak-1000-released.html
@@ -61,7 +61,7 @@
         This post is more than one year old. The contents within the blog is likely to be out of date.
         </div>
 
-<p>To download the release go to <a href="https://www.keycloak.org//downloads.html">Keycloak downloads</a>.</p>
+<p>To download the release go to <a href="https://www.keycloak.org/downloads.html">Keycloak downloads</a>.</p>
 
 <div class="sect1">
 <h2 id="_highlights">Highlights</h2>
@@ -131,7 +131,7 @@ some response are missing headers.</p>
 <p>The full list of resolved issues are available in <a href="https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A10.0.0">GitHub Issues</a></p>
 
 <h2>Upgrading</h2>
-<p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org//docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>
+<p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org/docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>
     </div>
 </div>
 		</div>

--- a/2020/04/keycloak-1000-released.html
+++ b/2020/04/keycloak-1000-released.html
@@ -128,7 +128,7 @@ some response are missing headers.</p>
 </div>
 </div>
 <h2>All resolved issues</h2>
-<p>The full list of resolved issues are available in <a href="https://github.com/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A10.0.0">GitHub Issues</a></p>
+<p>The full list of resolved issues are available in <a href="https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A10.0.0">GitHub Issues</a></p>
 
 <h2>Upgrading</h2>
 <p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org//docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>

--- a/2020/04/keycloak-903-released.html
+++ b/2020/04/keycloak-903-released.html
@@ -65,7 +65,7 @@
 
 
 <h2>All resolved issues</h2>
-<p>The full list of resolved issues are available in <a href="https://github.com/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A9.0.3">GitHub Issues</a></p>
+<p>The full list of resolved issues are available in <a href="https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A9.0.3">GitHub Issues</a></p>
 
 <h2>Upgrading</h2>
 <p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org//docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>

--- a/2020/04/keycloak-903-released.html
+++ b/2020/04/keycloak-903-released.html
@@ -61,14 +61,14 @@
         This post is more than one year old. The contents within the blog is likely to be out of date.
         </div>
 
-<p>To download the release go to <a href="https://www.keycloak.org//downloads.html">Keycloak downloads</a>.</p>
+<p>To download the release go to <a href="https://www.keycloak.org/downloads.html">Keycloak downloads</a>.</p>
 
 
 <h2>All resolved issues</h2>
 <p>The full list of resolved issues are available in <a href="https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A9.0.3">GitHub Issues</a></p>
 
 <h2>Upgrading</h2>
-<p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org//docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>
+<p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org/docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>
     </div>
 </div>
 		</div>

--- a/2020/05/keycloak-1001-released.html
+++ b/2020/05/keycloak-1001-released.html
@@ -61,14 +61,14 @@
         This post is more than one year old. The contents within the blog is likely to be out of date.
         </div>
 
-<p>To download the release go to <a href="https://www.keycloak.org//downloads.html">Keycloak downloads</a>.</p>
+<p>To download the release go to <a href="https://www.keycloak.org/downloads.html">Keycloak downloads</a>.</p>
 
 
 <h2>All resolved issues</h2>
 <p>The full list of resolved issues are available in <a href="https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A10.0.1">GitHub Issues</a></p>
 
 <h2>Upgrading</h2>
-<p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org//docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>
+<p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org/docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>
     </div>
 </div>
 		</div>

--- a/2020/05/keycloak-1001-released.html
+++ b/2020/05/keycloak-1001-released.html
@@ -65,7 +65,7 @@
 
 
 <h2>All resolved issues</h2>
-<p>The full list of resolved issues are available in <a href="https://github.com/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A10.0.1">GitHub Issues</a></p>
+<p>The full list of resolved issues are available in <a href="https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A10.0.1">GitHub Issues</a></p>
 
 <h2>Upgrading</h2>
 <p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org//docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>

--- a/2020/06/keycloak-1002-released.html
+++ b/2020/06/keycloak-1002-released.html
@@ -61,14 +61,14 @@
         This post is more than one year old. The contents within the blog is likely to be out of date.
         </div>
 
-<p>To download the release go to <a href="https://www.keycloak.org//downloads.html">Keycloak downloads</a>.</p>
+<p>To download the release go to <a href="https://www.keycloak.org/downloads.html">Keycloak downloads</a>.</p>
 
 
 <h2>All resolved issues</h2>
 <p>The full list of resolved issues are available in <a href="https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A10.0.2">GitHub Issues</a></p>
 
 <h2>Upgrading</h2>
-<p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org//docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>
+<p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org/docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>
     </div>
 </div>
 		</div>

--- a/2020/06/keycloak-1002-released.html
+++ b/2020/06/keycloak-1002-released.html
@@ -65,7 +65,7 @@
 
 
 <h2>All resolved issues</h2>
-<p>The full list of resolved issues are available in <a href="https://github.com/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A10.0.2">GitHub Issues</a></p>
+<p>The full list of resolved issues are available in <a href="https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A10.0.2">GitHub Issues</a></p>
 
 <h2>Upgrading</h2>
 <p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org//docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>

--- a/2020/07/keycloak-1100-released.html
+++ b/2020/07/keycloak-1100-released.html
@@ -129,7 +129,7 @@ workaround should be working also with the previous versions of the adapter.</p>
 </div>
 </div>
 <h2>All resolved issues</h2>
-<p>The full list of resolved issues are available in <a href="https://github.com/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A11.0.0">GitHub Issues</a></p>
+<p>The full list of resolved issues are available in <a href="https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A11.0.0">GitHub Issues</a></p>
 
 <h2>Upgrading</h2>
 <p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org//docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>

--- a/2020/07/keycloak-1100-released.html
+++ b/2020/07/keycloak-1100-released.html
@@ -61,7 +61,7 @@
         This post is more than one year old. The contents within the blog is likely to be out of date.
         </div>
 
-<p>To download the release go to <a href="https://www.keycloak.org//downloads.html">Keycloak downloads</a>.</p>
+<p>To download the release go to <a href="https://www.keycloak.org/downloads.html">Keycloak downloads</a>.</p>
 
 <div class="sect1">
 <h2 id="_highlights">Highlights</h2>
@@ -132,7 +132,7 @@ workaround should be working also with the previous versions of the adapter.</p>
 <p>The full list of resolved issues are available in <a href="https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A11.0.0">GitHub Issues</a></p>
 
 <h2>Upgrading</h2>
-<p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org//docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>
+<p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org/docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>
     </div>
 </div>
 		</div>

--- a/2020/08/keycloak-1101-released.html
+++ b/2020/08/keycloak-1101-released.html
@@ -61,14 +61,14 @@
         This post is more than one year old. The contents within the blog is likely to be out of date.
         </div>
 
-<p>To download the release go to <a href="https://www.keycloak.org//downloads.html">Keycloak downloads</a>.</p>
+<p>To download the release go to <a href="https://www.keycloak.org/downloads.html">Keycloak downloads</a>.</p>
 
 
 <h2>All resolved issues</h2>
 <p>The full list of resolved issues are available in <a href="https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A11.0.1">GitHub Issues</a></p>
 
 <h2>Upgrading</h2>
-<p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org//docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>
+<p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org/docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>
     </div>
 </div>
 		</div>

--- a/2020/08/keycloak-1101-released.html
+++ b/2020/08/keycloak-1101-released.html
@@ -65,7 +65,7 @@
 
 
 <h2>All resolved issues</h2>
-<p>The full list of resolved issues are available in <a href="https://github.com/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A11.0.1">GitHub Issues</a></p>
+<p>The full list of resolved issues are available in <a href="https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A11.0.1">GitHub Issues</a></p>
 
 <h2>Upgrading</h2>
 <p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org//docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>

--- a/2020/08/keycloak-1102-released.html
+++ b/2020/08/keycloak-1102-released.html
@@ -65,7 +65,7 @@
 
 
 <h2>All resolved issues</h2>
-<p>The full list of resolved issues are available in <a href="https://github.com/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A11.0.2">GitHub Issues</a></p>
+<p>The full list of resolved issues are available in <a href="https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A11.0.2">GitHub Issues</a></p>
 
 <h2>Upgrading</h2>
 <p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org//docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>

--- a/2020/08/keycloak-1102-released.html
+++ b/2020/08/keycloak-1102-released.html
@@ -61,14 +61,14 @@
         This post is more than one year old. The contents within the blog is likely to be out of date.
         </div>
 
-<p>To download the release go to <a href="https://www.keycloak.org//downloads.html">Keycloak downloads</a>.</p>
+<p>To download the release go to <a href="https://www.keycloak.org/downloads.html">Keycloak downloads</a>.</p>
 
 
 <h2>All resolved issues</h2>
 <p>The full list of resolved issues are available in <a href="https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A11.0.2">GitHub Issues</a></p>
 
 <h2>Upgrading</h2>
-<p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org//docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>
+<p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org/docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>
     </div>
 </div>
 		</div>

--- a/2020/09/new-account-console.adoc.html
+++ b/2020/09/new-account-console.adoc.html
@@ -74,13 +74,13 @@
 <h2 id="_screen_shots_of_new_account_management_console">Screen shots of New Account Management Console</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p><span class="image"><img src="https://www.keycloak.org//resources/images/blog/new-account-console/welcome-screen.png" alt="alt"></span></p>
+<p><span class="image"><img src="https://www.keycloak.org/resources/images/blog/new-account-console/welcome-screen.png" alt="alt"></span></p>
 </div>
 <div class="paragraph">
-<p><span class="image"><img src="https://www.keycloak.org//resources/images/blog/new-account-console/main-screen.png" alt="alt"></span></p>
+<p><span class="image"><img src="https://www.keycloak.org/resources/images/blog/new-account-console/main-screen.png" alt="alt"></span></p>
 </div>
 <div class="paragraph">
-<p><span class="image"><img src="https://www.keycloak.org//resources/images/blog/new-account-console/device-activity.png" alt="alt"></span></p>
+<p><span class="image"><img src="https://www.keycloak.org/resources/images/blog/new-account-console/device-activity.png" alt="alt"></span></p>
 </div>
 </div>
 </div>
@@ -101,7 +101,7 @@
 </div>
 </div>
 <div class="paragraph">
-<p><span class="image"><img src="https://www.keycloak.org//resources/images/blog/new-account-console/keycloak-man-welcome-screen.png" alt="alt"></span></p>
+<p><span class="image"><img src="https://www.keycloak.org/resources/images/blog/new-account-console/keycloak-man-welcome-screen.png" alt="alt"></span></p>
 </div>
 </div>
 </div>
@@ -115,13 +115,13 @@
 <p>It&#8217;s even possible to build new pages with nothing but an editor.  No build step is required unless you want to use more advanced tools like JSX and Typescript.</p>
 </div>
 <div class="paragraph">
-<p><span class="image"><img src="https://www.keycloak.org//resources/images/blog/new-account-console/who-is-keycloak-man.png" alt="alt"></span></p>
+<p><span class="image"><img src="https://www.keycloak.org/resources/images/blog/new-account-console/who-is-keycloak-man.png" alt="alt"></span></p>
 </div>
 <div class="paragraph">
-<p><span class="image"><img src="https://www.keycloak.org//resources/images/blog/new-account-console/keycloak-man-overview.png" alt="alt"></span></p>
+<p><span class="image"><img src="https://www.keycloak.org/resources/images/blog/new-account-console/keycloak-man-overview.png" alt="alt"></span></p>
 </div>
 <div class="paragraph">
-<p><span class="image"><img src="https://www.keycloak.org//resources/images/blog/new-account-console/keycloak-man-jsx.png" alt="alt"></span></p>
+<p><span class="image"><img src="https://www.keycloak.org/resources/images/blog/new-account-console/keycloak-man-jsx.png" alt="alt"></span></p>
 </div>
 <div class="paragraph">
 <p>Of course, this "Keycloak Man" theme is available online as a Keycloak Quick Start so you can check out all the source.</p>

--- a/2020/11/keycloak-1103-released.html
+++ b/2020/11/keycloak-1103-released.html
@@ -65,7 +65,7 @@
 
 
 <h2>All resolved issues</h2>
-<p>The full list of resolved issues are available in <a href="https://github.com/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A11.0.3">GitHub Issues</a></p>
+<p>The full list of resolved issues are available in <a href="https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A11.0.3">GitHub Issues</a></p>
 
 <h2>Upgrading</h2>
 <p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org//docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>

--- a/2020/11/keycloak-1103-released.html
+++ b/2020/11/keycloak-1103-released.html
@@ -61,14 +61,14 @@
         This post is more than one year old. The contents within the blog is likely to be out of date.
         </div>
 
-<p>To download the release go to <a href="https://www.keycloak.org//downloads.html">Keycloak downloads</a>.</p>
+<p>To download the release go to <a href="https://www.keycloak.org/downloads.html">Keycloak downloads</a>.</p>
 
 
 <h2>All resolved issues</h2>
 <p>The full list of resolved issues are available in <a href="https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A11.0.3">GitHub Issues</a></p>
 
 <h2>Upgrading</h2>
-<p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org//docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>
+<p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org/docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>
     </div>
 </div>
 		</div>

--- a/2020/12/keycloak-1200-released.html
+++ b/2020/12/keycloak-1200-released.html
@@ -145,7 +145,7 @@ For details, please refer to the <a href="https://www.keycloak.org/docs/latest/s
 </div>
 </div>
 <h2>All resolved issues</h2>
-<p>The full list of resolved issues are available in <a href="https://github.com/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A12.0.0">GitHub Issues</a></p>
+<p>The full list of resolved issues are available in <a href="https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A12.0.0">GitHub Issues</a></p>
 
 <h2>Upgrading</h2>
 <p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org//docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>

--- a/2020/12/keycloak-1200-released.html
+++ b/2020/12/keycloak-1200-released.html
@@ -61,7 +61,7 @@
         This post is more than one year old. The contents within the blog is likely to be out of date.
         </div>
 
-<p>To download the release go to <a href="https://www.keycloak.org//downloads.html">Keycloak downloads</a>.</p>
+<p>To download the release go to <a href="https://www.keycloak.org/downloads.html">Keycloak downloads</a>.</p>
 
 <div class="sect1">
 <h2 id="_highlights">Highlights</h2>
@@ -148,7 +148,7 @@ For details, please refer to the <a href="https://www.keycloak.org/docs/latest/s
 <p>The full list of resolved issues are available in <a href="https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A12.0.0">GitHub Issues</a></p>
 
 <h2>Upgrading</h2>
-<p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org//docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>
+<p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org/docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>
     </div>
 </div>
 		</div>

--- a/2020/12/keycloak-1201-released.html
+++ b/2020/12/keycloak-1201-released.html
@@ -61,14 +61,14 @@
         This post is more than one year old. The contents within the blog is likely to be out of date.
         </div>
 
-<p>To download the release go to <a href="https://www.keycloak.org//downloads.html">Keycloak downloads</a>.</p>
+<p>To download the release go to <a href="https://www.keycloak.org/downloads.html">Keycloak downloads</a>.</p>
 
 
 <h2>All resolved issues</h2>
 <p>The full list of resolved issues are available in <a href="https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A12.0.1">GitHub Issues</a></p>
 
 <h2>Upgrading</h2>
-<p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org//docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>
+<p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org/docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>
     </div>
 </div>
 		</div>

--- a/2020/12/keycloak-1201-released.html
+++ b/2020/12/keycloak-1201-released.html
@@ -65,7 +65,7 @@
 
 
 <h2>All resolved issues</h2>
-<p>The full list of resolved issues are available in <a href="https://github.com/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A12.0.1">GitHub Issues</a></p>
+<p>The full list of resolved issues are available in <a href="https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A12.0.1">GitHub Issues</a></p>
 
 <h2>Upgrading</h2>
 <p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org//docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>

--- a/2021/01/keycloak-1202-released.html
+++ b/2021/01/keycloak-1202-released.html
@@ -58,14 +58,14 @@
         <p class="blog-date">Tuesday, January 19 2021</p>
 
 
-<p>To download the release go to <a href="https://www.keycloak.org//downloads.html">Keycloak downloads</a>.</p>
+<p>To download the release go to <a href="https://www.keycloak.org/downloads.html">Keycloak downloads</a>.</p>
 
 
 <h2>All resolved issues</h2>
 <p>The full list of resolved issues are available in <a href="https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A12.0.2">GitHub Issues</a></p>
 
 <h2>Upgrading</h2>
-<p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org//docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>
+<p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org/docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>
     </div>
 </div>
 		</div>

--- a/2021/01/keycloak-1202-released.html
+++ b/2021/01/keycloak-1202-released.html
@@ -62,7 +62,7 @@
 
 
 <h2>All resolved issues</h2>
-<p>The full list of resolved issues are available in <a href="https://github.com/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A12.0.2">GitHub Issues</a></p>
+<p>The full list of resolved issues are available in <a href="https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A12.0.2">GitHub Issues</a></p>
 
 <h2>Upgrading</h2>
 <p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org//docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>

--- a/2021/02/keycloak-1203-released.html
+++ b/2021/02/keycloak-1203-released.html
@@ -62,7 +62,7 @@
 
 
 <h2>All resolved issues</h2>
-<p>The full list of resolved issues are available in <a href="https://github.com/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A12.0.3">GitHub Issues</a></p>
+<p>The full list of resolved issues are available in <a href="https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A12.0.3">GitHub Issues</a></p>
 
 <h2>Upgrading</h2>
 <p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org//docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>

--- a/2021/02/keycloak-1203-released.html
+++ b/2021/02/keycloak-1203-released.html
@@ -58,14 +58,14 @@
         <p class="blog-date">Tuesday, February 16 2021</p>
 
 
-<p>To download the release go to <a href="https://www.keycloak.org//downloads.html">Keycloak downloads</a>.</p>
+<p>To download the release go to <a href="https://www.keycloak.org/downloads.html">Keycloak downloads</a>.</p>
 
 
 <h2>All resolved issues</h2>
 <p>The full list of resolved issues are available in <a href="https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A12.0.3">GitHub Issues</a></p>
 
 <h2>Upgrading</h2>
-<p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org//docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>
+<p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org/docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>
     </div>
 </div>
 		</div>

--- a/2021/03/keycloak-1204-released.html
+++ b/2021/03/keycloak-1204-released.html
@@ -62,7 +62,7 @@
 
 
 <h2>All resolved issues</h2>
-<p>The full list of resolved issues are available in <a href="https://github.com/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A12.0.4">GitHub Issues</a></p>
+<p>The full list of resolved issues are available in <a href="https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A12.0.4">GitHub Issues</a></p>
 
 <h2>Upgrading</h2>
 <p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org//docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>

--- a/2021/03/keycloak-1204-released.html
+++ b/2021/03/keycloak-1204-released.html
@@ -58,14 +58,14 @@
         <p class="blog-date">Monday, March 01 2021</p>
 
 
-<p>To download the release go to <a href="https://www.keycloak.org//downloads.html">Keycloak downloads</a>.</p>
+<p>To download the release go to <a href="https://www.keycloak.org/downloads.html">Keycloak downloads</a>.</p>
 
 
 <h2>All resolved issues</h2>
 <p>The full list of resolved issues are available in <a href="https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A12.0.4">GitHub Issues</a></p>
 
 <h2>Upgrading</h2>
-<p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org//docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>
+<p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org/docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>
     </div>
 </div>
 		</div>

--- a/2021/05/keycloak-1300-released.html
+++ b/2021/05/keycloak-1300-released.html
@@ -58,7 +58,7 @@
         <p class="blog-date">Thursday, May 06 2021</p>
 
 
-<p>To download the release go to <a href="https://www.keycloak.org//downloads.html">Keycloak downloads</a>.</p>
+<p>To download the release go to <a href="https://www.keycloak.org/downloads.html">Keycloak downloads</a>.</p>
 
 <div class="sect1">
 <h2 id="_highlights">Highlights</h2>
@@ -125,7 +125,7 @@ especially with larger number of clients, because it is no longer necessary to g
 <p>The full list of resolved issues are available in <a href="https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A13.0.0">GitHub Issues</a></p>
 
 <h2>Upgrading</h2>
-<p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org//docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>
+<p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org/docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>
     </div>
 </div>
 		</div>

--- a/2021/05/keycloak-1300-released.html
+++ b/2021/05/keycloak-1300-released.html
@@ -122,7 +122,7 @@ especially with larger number of clients, because it is no longer necessary to g
 </div>
 </div>
 <h2>All resolved issues</h2>
-<p>The full list of resolved issues are available in <a href="https://github.com/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A13.0.0">GitHub Issues</a></p>
+<p>The full list of resolved issues are available in <a href="https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A13.0.0">GitHub Issues</a></p>
 
 <h2>Upgrading</h2>
 <p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org//docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>

--- a/2021/05/keycloak-1301-released.html
+++ b/2021/05/keycloak-1301-released.html
@@ -58,14 +58,14 @@
         <p class="blog-date">Tuesday, May 25 2021</p>
 
 
-<p>To download the release go to <a href="https://www.keycloak.org//downloads.html">Keycloak downloads</a>.</p>
+<p>To download the release go to <a href="https://www.keycloak.org/downloads.html">Keycloak downloads</a>.</p>
 
 
 <h2>All resolved issues</h2>
 <p>The full list of resolved issues are available in <a href="https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A13.0.1">GitHub Issues</a></p>
 
 <h2>Upgrading</h2>
-<p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org//docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>
+<p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org/docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>
     </div>
 </div>
 		</div>

--- a/2021/05/keycloak-1301-released.html
+++ b/2021/05/keycloak-1301-released.html
@@ -62,7 +62,7 @@
 
 
 <h2>All resolved issues</h2>
-<p>The full list of resolved issues are available in <a href="https://github.com/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A13.0.1">GitHub Issues</a></p>
+<p>The full list of resolved issues are available in <a href="https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A13.0.1">GitHub Issues</a></p>
 
 <h2>Upgrading</h2>
 <p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org//docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>

--- a/2021/06/book.adoc.html
+++ b/2021/06/book.adoc.html
@@ -63,7 +63,7 @@
 </div>
 <div class="imageblock">
 <div class="content">
-<img src="https://www.keycloak.org//resources/images/blog/kcbook.jpg" alt="Book cover">
+<img src="https://www.keycloak.org/resources/images/blog/kcbook.jpg" alt="Book cover">
 </div>
 </div>
 <div class="paragraph">

--- a/2021/06/keycloak-1400-released.html
+++ b/2021/06/keycloak-1400-released.html
@@ -110,7 +110,7 @@ activated in the server configuration, see Server administration guide for detai
 </div>
 </div>
 <h2>All resolved issues</h2>
-<p>The full list of resolved issues are available in <a href="https://github.com/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A14.0.0">GitHub Issues</a></p>
+<p>The full list of resolved issues are available in <a href="https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A14.0.0">GitHub Issues</a></p>
 
 <h2>Upgrading</h2>
 <p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org//docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>

--- a/2021/06/keycloak-1400-released.html
+++ b/2021/06/keycloak-1400-released.html
@@ -58,7 +58,7 @@
         <p class="blog-date">Friday, June 18 2021</p>
 
 
-<p>To download the release go to <a href="https://www.keycloak.org//downloads.html">Keycloak downloads</a>.</p>
+<p>To download the release go to <a href="https://www.keycloak.org/downloads.html">Keycloak downloads</a>.</p>
 
 <div class="sect1">
 <h2 id="_highlights">Highlights</h2>
@@ -113,7 +113,7 @@ activated in the server configuration, see Server administration guide for detai
 <p>The full list of resolved issues are available in <a href="https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A14.0.0">GitHub Issues</a></p>
 
 <h2>Upgrading</h2>
-<p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org//docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>
+<p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org/docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>
     </div>
 </div>
 		</div>

--- a/2021/07/keycloak-1500-released.html
+++ b/2021/07/keycloak-1500-released.html
@@ -76,7 +76,7 @@ the work on the FAPI compliance as well. Finally thanks to all the members of th
 </div>
 </div>
 <h2>All resolved issues</h2>
-<p>The full list of resolved issues are available in <a href="https://github.com/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A15.0.0">GitHub Issues</a></p>
+<p>The full list of resolved issues are available in <a href="https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A15.0.0">GitHub Issues</a></p>
 
 <h2>Upgrading</h2>
 <p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org//docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>

--- a/2021/07/keycloak-1500-released.html
+++ b/2021/07/keycloak-1500-released.html
@@ -58,7 +58,7 @@
         <p class="blog-date">Friday, July 30 2021</p>
 
 
-<p>To download the release go to <a href="https://www.keycloak.org//downloads.html">Keycloak downloads</a>.</p>
+<p>To download the release go to <a href="https://www.keycloak.org/downloads.html">Keycloak downloads</a>.</p>
 
 <div class="sect1">
 <h2 id="_highlights">Highlights</h2>
@@ -79,7 +79,7 @@ the work on the FAPI compliance as well. Finally thanks to all the members of th
 <p>The full list of resolved issues are available in <a href="https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A15.0.0">GitHub Issues</a></p>
 
 <h2>Upgrading</h2>
-<p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org//docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>
+<p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org/docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>
     </div>
 </div>
 		</div>

--- a/2021/08/keycloak-1501-released.html
+++ b/2021/08/keycloak-1501-released.html
@@ -58,7 +58,7 @@
         <p class="blog-date">Saturday, August 07 2021</p>
 
 
-<p>To download the release go to <a href="https://www.keycloak.org//downloads.html">Keycloak downloads</a>.</p>
+<p>To download the release go to <a href="https://www.keycloak.org/downloads.html">Keycloak downloads</a>.</p>
 
 <div class="sect1">
 <h2 id="_highlights">Highlights</h2>
@@ -73,7 +73,7 @@ FAPI related functionalities such as JARM support and improvements in CIBA.</p>
 <p>The full list of resolved issues are available in <a href="https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A15.0.1">GitHub Issues</a></p>
 
 <h2>Upgrading</h2>
-<p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org//docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>
+<p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org/docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>
     </div>
 </div>
 		</div>

--- a/2021/08/keycloak-1501-released.html
+++ b/2021/08/keycloak-1501-released.html
@@ -70,7 +70,7 @@ FAPI related functionalities such as JARM support and improvements in CIBA.</p>
 </div>
 </div>
 <h2>All resolved issues</h2>
-<p>The full list of resolved issues are available in <a href="https://github.com/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A15.0.1">GitHub Issues</a></p>
+<p>The full list of resolved issues are available in <a href="https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A15.0.1">GitHub Issues</a></p>
 
 <h2>Upgrading</h2>
 <p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org//docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>

--- a/2021/08/keycloak-1502-released.html
+++ b/2021/08/keycloak-1502-released.html
@@ -62,7 +62,7 @@
 
 
 <h2>All resolved issues</h2>
-<p>The full list of resolved issues are available in <a href="https://github.com/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A15.0.2">GitHub Issues</a></p>
+<p>The full list of resolved issues are available in <a href="https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A15.0.2">GitHub Issues</a></p>
 
 <h2>Upgrading</h2>
 <p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org//docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>

--- a/2021/08/keycloak-1502-released.html
+++ b/2021/08/keycloak-1502-released.html
@@ -58,14 +58,14 @@
         <p class="blog-date">Friday, August 20 2021</p>
 
 
-<p>To download the release go to <a href="https://www.keycloak.org//downloads.html">Keycloak downloads</a>.</p>
+<p>To download the release go to <a href="https://www.keycloak.org/downloads.html">Keycloak downloads</a>.</p>
 
 
 <h2>All resolved issues</h2>
 <p>The full list of resolved issues are available in <a href="https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A15.0.2">GitHub Issues</a></p>
 
 <h2>Upgrading</h2>
-<p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org//docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>
+<p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org/docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>
     </div>
 </div>
 		</div>

--- a/2021/12/keycloak-1510-released.html
+++ b/2021/12/keycloak-1510-released.html
@@ -58,7 +58,7 @@
         <p class="blog-date">Friday, December 10 2021</p>
 
 
-<p>To download the release go to <a href="https://www.keycloak.org//downloads.html">Keycloak downloads</a>.</p>
+<p>To download the release go to <a href="https://www.keycloak.org/downloads.html">Keycloak downloads</a>.</p>
 
 <div class="sect1">
 <h2 id="_highlights">Highlights</h2>
@@ -134,7 +134,7 @@ concerns the Backup CRD and the operator managed Postgres Database. For more det
 <p>The full list of resolved issues are available in <a href="https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A15.1.0">GitHub Issues</a></p>
 
 <h2>Upgrading</h2>
-<p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org//docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>
+<p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org/docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>
     </div>
 </div>
 		</div>

--- a/2021/12/keycloak-1510-released.html
+++ b/2021/12/keycloak-1510-released.html
@@ -131,7 +131,7 @@ concerns the Backup CRD and the operator managed Postgres Database. For more det
 </div>
 </div>
 <h2>All resolved issues</h2>
-<p>The full list of resolved issues are available in <a href="https://github.com/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A15.1.0">GitHub Issues</a></p>
+<p>The full list of resolved issues are available in <a href="https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A15.1.0">GitHub Issues</a></p>
 
 <h2>Upgrading</h2>
 <p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org//docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>

--- a/2021/12/keycloak-1511-released.html
+++ b/2021/12/keycloak-1511-released.html
@@ -62,7 +62,7 @@
 
 
 <h2>All resolved issues</h2>
-<p>The full list of resolved issues are available in <a href="https://github.com/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A15.1.1">GitHub Issues</a></p>
+<p>The full list of resolved issues are available in <a href="https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A15.1.1">GitHub Issues</a></p>
 
 <h2>Upgrading</h2>
 <p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org//docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>

--- a/2021/12/keycloak-1511-released.html
+++ b/2021/12/keycloak-1511-released.html
@@ -58,14 +58,14 @@
         <p class="blog-date">Friday, December 17 2021</p>
 
 
-<p>To download the release go to <a href="https://www.keycloak.org//downloads.html">Keycloak downloads</a>.</p>
+<p>To download the release go to <a href="https://www.keycloak.org/downloads.html">Keycloak downloads</a>.</p>
 
 
 <h2>All resolved issues</h2>
 <p>The full list of resolved issues are available in <a href="https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A15.1.1">GitHub Issues</a></p>
 
 <h2>Upgrading</h2>
-<p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org//docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>
+<p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org/docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>
     </div>
 </div>
 		</div>

--- a/2021/12/keycloak-1600-released.html
+++ b/2021/12/keycloak-1600-released.html
@@ -84,7 +84,7 @@
 </div>
 </div>
 <h2>All resolved issues</h2>
-<p>The full list of resolved issues are available in <a href="https://github.com/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.0.0">GitHub Issues</a></p>
+<p>The full list of resolved issues are available in <a href="https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.0.0">GitHub Issues</a></p>
 
 <h2>Upgrading</h2>
 <p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org//docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>

--- a/2021/12/keycloak-1600-released.html
+++ b/2021/12/keycloak-1600-released.html
@@ -58,7 +58,7 @@
         <p class="blog-date">Friday, December 17 2021</p>
 
 
-<p>To download the release go to <a href="https://www.keycloak.org//downloads.html">Keycloak downloads</a>.</p>
+<p>To download the release go to <a href="https://www.keycloak.org/downloads.html">Keycloak downloads</a>.</p>
 
 <div class="sect1">
 <h2 id="_highlights">Highlights</h2>
@@ -87,7 +87,7 @@
 <p>The full list of resolved issues are available in <a href="https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.0.0">GitHub Issues</a></p>
 
 <h2>Upgrading</h2>
-<p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org//docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>
+<p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org/docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>
     </div>
 </div>
 		</div>

--- a/2021/12/keycloak-1610-released.html
+++ b/2021/12/keycloak-1610-released.html
@@ -58,7 +58,7 @@
         <p class="blog-date">Monday, December 20 2021</p>
 
 
-<p>To download the release go to <a href="https://www.keycloak.org//downloads.html">Keycloak downloads</a>.</p>
+<p>To download the release go to <a href="https://www.keycloak.org/downloads.html">Keycloak downloads</a>.</p>
 
 <div class="sect1">
 <h2 id="_highlights">Highlights</h2>
@@ -78,7 +78,7 @@
 <p>The full list of resolved issues are available in <a href="https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0">GitHub Issues</a></p>
 
 <h2>Upgrading</h2>
-<p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org//docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>
+<p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org/docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>
     </div>
 </div>
 		</div>

--- a/2021/12/keycloak-1610-released.html
+++ b/2021/12/keycloak-1610-released.html
@@ -75,7 +75,7 @@
 </div>
 </div>
 <h2>All resolved issues</h2>
-<p>The full list of resolved issues are available in <a href="https://github.com/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0">GitHub Issues</a></p>
+<p>The full list of resolved issues are available in <a href="https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0">GitHub Issues</a></p>
 
 <h2>Upgrading</h2>
 <p>Before you upgrade remember to backup your database and check the <a href="https://www.keycloak.org//docs/latest/upgrading/index.html">upgrade guide</a> for anything that may have changed.</p>

--- a/rss.xml
+++ b/rss.xml
@@ -4,14 +4,14 @@
 <channel>
   <title>Keycloak Blog</title>
   <link>https://www.keycloak.org/blog.html</link>
-  <atom:link href="https://www.keycloak.org//rss.xml" rel="self" type="application/rss+xml" />
+  <atom:link href="https://www.keycloak.org/rss.xml" rel="self" type="application/rss+xml" />
   <description>Keycloak Blog</description>
   <language>en-us</language>
   <category>Keycloak/SSO/Identity and Access Management</category>
       <item>
         <title>Keycloak 16.1.0 released</title>
         <link>https://www.keycloak.org/2021/12/keycloak-1610-released</link>
-        <description>&lt;p&gt;To download the release go to &lt;a href=&quot;https://www.keycloak.org//downloads.html&quot;&gt;Keycloak downloads&lt;/a&gt;.&lt;/p&gt;
+        <description>&lt;p&gt;To download the release go to &lt;a href=&quot;https://www.keycloak.org/downloads.html&quot;&gt;Keycloak downloads&lt;/a&gt;.&lt;/p&gt;
 
 &lt;div class=&quot;sect1&quot;&gt;
 &lt;h2 id=&quot;_highlights&quot;&gt;Highlights&lt;/h2&gt;
@@ -31,7 +31,7 @@
 &lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
 
 &lt;h2&gt;Upgrading&lt;/h2&gt;
-&lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org//docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
+&lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org/docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
 </description>
         <guid>https://www.keycloak.org/2021/12/keycloak-1610-released</guid>
         <pubDate>Mon, 20 Dec 2021 00:00:00 GMT</pubDate>
@@ -41,7 +41,7 @@
       <item>
         <title>Keycloak 16.0.0 released</title>
         <link>https://www.keycloak.org/2021/12/keycloak-1600-released</link>
-        <description>&lt;p&gt;To download the release go to &lt;a href=&quot;https://www.keycloak.org//downloads.html&quot;&gt;Keycloak downloads&lt;/a&gt;.&lt;/p&gt;
+        <description>&lt;p&gt;To download the release go to &lt;a href=&quot;https://www.keycloak.org/downloads.html&quot;&gt;Keycloak downloads&lt;/a&gt;.&lt;/p&gt;
 
 &lt;div class=&quot;sect1&quot;&gt;
 &lt;h2 id=&quot;_highlights&quot;&gt;Highlights&lt;/h2&gt;
@@ -61,7 +61,7 @@
 &lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
 
 &lt;h2&gt;Upgrading&lt;/h2&gt;
-&lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org//docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
+&lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org/docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
 </description>
         <guid>https://www.keycloak.org/2021/12/keycloak-1600-released</guid>
         <pubDate>Fri, 17 Dec 2021 00:00:00 GMT</pubDate>
@@ -71,7 +71,7 @@
       <item>
         <title>Keycloak 15.1.1 released</title>
         <link>https://www.keycloak.org/2021/12/keycloak-1511-released</link>
-        <description>&lt;p&gt;To download the release go to &lt;a href=&quot;https://www.keycloak.org//downloads.html&quot;&gt;Keycloak downloads&lt;/a&gt;.&lt;/p&gt;
+        <description>&lt;p&gt;To download the release go to &lt;a href=&quot;https://www.keycloak.org/downloads.html&quot;&gt;Keycloak downloads&lt;/a&gt;.&lt;/p&gt;
 
 &lt;div class=&quot;sect1&quot;&gt;
 &lt;h2 id=&quot;_highlights&quot;&gt;Highlights&lt;/h2&gt;
@@ -91,7 +91,7 @@
 &lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
 
 &lt;h2&gt;Upgrading&lt;/h2&gt;
-&lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org//docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
+&lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org/docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
 </description>
         <guid>https://www.keycloak.org/2021/12/keycloak-1511-released</guid>
         <pubDate>Fri, 17 Dec 2021 00:00:00 GMT</pubDate>
@@ -101,7 +101,7 @@
       <item>
         <title>Keycloak 15.1.0 released</title>
         <link>https://www.keycloak.org/2021/12/keycloak-1510-released</link>
-        <description>&lt;p&gt;To download the release go to &lt;a href=&quot;https://www.keycloak.org//downloads.html&quot;&gt;Keycloak downloads&lt;/a&gt;.&lt;/p&gt;
+        <description>&lt;p&gt;To download the release go to &lt;a href=&quot;https://www.keycloak.org/downloads.html&quot;&gt;Keycloak downloads&lt;/a&gt;.&lt;/p&gt;
 
 &lt;div class=&quot;sect1&quot;&gt;
 &lt;h2 id=&quot;_highlights&quot;&gt;Highlights&lt;/h2&gt;
@@ -121,7 +121,7 @@
 &lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
 
 &lt;h2&gt;Upgrading&lt;/h2&gt;
-&lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org//docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
+&lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org/docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
 </description>
         <guid>https://www.keycloak.org/2021/12/keycloak-1510-released</guid>
         <pubDate>Fri, 10 Dec 2021 00:00:00 GMT</pubDate>
@@ -328,7 +328,7 @@
       <item>
         <title>Keycloak 15.0.2 released</title>
         <link>https://www.keycloak.org/2021/08/keycloak-1502-released</link>
-        <description>&lt;p&gt;To download the release go to &lt;a href=&quot;https://www.keycloak.org//downloads.html&quot;&gt;Keycloak downloads&lt;/a&gt;.&lt;/p&gt;
+        <description>&lt;p&gt;To download the release go to &lt;a href=&quot;https://www.keycloak.org/downloads.html&quot;&gt;Keycloak downloads&lt;/a&gt;.&lt;/p&gt;
 
 &lt;div class=&quot;sect1&quot;&gt;
 &lt;h2 id=&quot;_highlights&quot;&gt;Highlights&lt;/h2&gt;
@@ -348,7 +348,7 @@
 &lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
 
 &lt;h2&gt;Upgrading&lt;/h2&gt;
-&lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org//docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
+&lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org/docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
 </description>
         <guid>https://www.keycloak.org/2021/08/keycloak-1502-released</guid>
         <pubDate>Fri, 20 Aug 2021 00:00:00 GMT</pubDate>
@@ -358,7 +358,7 @@
       <item>
         <title>Keycloak 15.0.1 released</title>
         <link>https://www.keycloak.org/2021/08/keycloak-1501-released</link>
-        <description>&lt;p&gt;To download the release go to &lt;a href=&quot;https://www.keycloak.org//downloads.html&quot;&gt;Keycloak downloads&lt;/a&gt;.&lt;/p&gt;
+        <description>&lt;p&gt;To download the release go to &lt;a href=&quot;https://www.keycloak.org/downloads.html&quot;&gt;Keycloak downloads&lt;/a&gt;.&lt;/p&gt;
 
 &lt;div class=&quot;sect1&quot;&gt;
 &lt;h2 id=&quot;_highlights&quot;&gt;Highlights&lt;/h2&gt;
@@ -378,7 +378,7 @@
 &lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
 
 &lt;h2&gt;Upgrading&lt;/h2&gt;
-&lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org//docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
+&lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org/docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
 </description>
         <guid>https://www.keycloak.org/2021/08/keycloak-1501-released</guid>
         <pubDate>Sat, 7 Aug 2021 00:00:00 GMT</pubDate>
@@ -388,7 +388,7 @@
       <item>
         <title>Keycloak 15.0.0 released</title>
         <link>https://www.keycloak.org/2021/07/keycloak-1500-released</link>
-        <description>&lt;p&gt;To download the release go to &lt;a href=&quot;https://www.keycloak.org//downloads.html&quot;&gt;Keycloak downloads&lt;/a&gt;.&lt;/p&gt;
+        <description>&lt;p&gt;To download the release go to &lt;a href=&quot;https://www.keycloak.org/downloads.html&quot;&gt;Keycloak downloads&lt;/a&gt;.&lt;/p&gt;
 
 &lt;div class=&quot;sect1&quot;&gt;
 &lt;h2 id=&quot;_highlights&quot;&gt;Highlights&lt;/h2&gt;
@@ -408,7 +408,7 @@
 &lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
 
 &lt;h2&gt;Upgrading&lt;/h2&gt;
-&lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org//docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
+&lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org/docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
 </description>
         <guid>https://www.keycloak.org/2021/07/keycloak-1500-released</guid>
         <pubDate>Fri, 30 Jul 2021 00:00:00 GMT</pubDate>
@@ -423,7 +423,7 @@
 &lt;/div&gt;
 &lt;div class=&quot;imageblock&quot;&gt;
 &lt;div class=&quot;content&quot;&gt;
-&lt;img src=&quot;https://www.keycloak.org//resources/images/blog/kcbook.jpg&quot; alt=&quot;Book cover&quot;&gt;
+&lt;img src=&quot;https://www.keycloak.org/resources/images/blog/kcbook.jpg&quot; alt=&quot;Book cover&quot;&gt;
 &lt;/div&gt;
 &lt;/div&gt;
 &lt;div class=&quot;paragraph&quot;&gt;
@@ -440,7 +440,7 @@
       <item>
         <title>Keycloak 14.0.0 released</title>
         <link>https://www.keycloak.org/2021/06/keycloak-1400-released</link>
-        <description>&lt;p&gt;To download the release go to &lt;a href=&quot;https://www.keycloak.org//downloads.html&quot;&gt;Keycloak downloads&lt;/a&gt;.&lt;/p&gt;
+        <description>&lt;p&gt;To download the release go to &lt;a href=&quot;https://www.keycloak.org/downloads.html&quot;&gt;Keycloak downloads&lt;/a&gt;.&lt;/p&gt;
 
 &lt;div class=&quot;sect1&quot;&gt;
 &lt;h2 id=&quot;_highlights&quot;&gt;Highlights&lt;/h2&gt;
@@ -460,7 +460,7 @@
 &lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
 
 &lt;h2&gt;Upgrading&lt;/h2&gt;
-&lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org//docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
+&lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org/docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
 </description>
         <guid>https://www.keycloak.org/2021/06/keycloak-1400-released</guid>
         <pubDate>Fri, 18 Jun 2021 00:00:00 GMT</pubDate>
@@ -470,7 +470,7 @@
       <item>
         <title>Keycloak 13.0.1 released</title>
         <link>https://www.keycloak.org/2021/05/keycloak-1301-released</link>
-        <description>&lt;p&gt;To download the release go to &lt;a href=&quot;https://www.keycloak.org//downloads.html&quot;&gt;Keycloak downloads&lt;/a&gt;.&lt;/p&gt;
+        <description>&lt;p&gt;To download the release go to &lt;a href=&quot;https://www.keycloak.org/downloads.html&quot;&gt;Keycloak downloads&lt;/a&gt;.&lt;/p&gt;
 
 &lt;div class=&quot;sect1&quot;&gt;
 &lt;h2 id=&quot;_highlights&quot;&gt;Highlights&lt;/h2&gt;
@@ -490,7 +490,7 @@
 &lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
 
 &lt;h2&gt;Upgrading&lt;/h2&gt;
-&lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org//docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
+&lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org/docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
 </description>
         <guid>https://www.keycloak.org/2021/05/keycloak-1301-released</guid>
         <pubDate>Tue, 25 May 2021 00:00:00 GMT</pubDate>
@@ -500,7 +500,7 @@
       <item>
         <title>Keycloak 13.0.0 released</title>
         <link>https://www.keycloak.org/2021/05/keycloak-1300-released</link>
-        <description>&lt;p&gt;To download the release go to &lt;a href=&quot;https://www.keycloak.org//downloads.html&quot;&gt;Keycloak downloads&lt;/a&gt;.&lt;/p&gt;
+        <description>&lt;p&gt;To download the release go to &lt;a href=&quot;https://www.keycloak.org/downloads.html&quot;&gt;Keycloak downloads&lt;/a&gt;.&lt;/p&gt;
 
 &lt;div class=&quot;sect1&quot;&gt;
 &lt;h2 id=&quot;_highlights&quot;&gt;Highlights&lt;/h2&gt;
@@ -520,7 +520,7 @@
 &lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
 
 &lt;h2&gt;Upgrading&lt;/h2&gt;
-&lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org//docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
+&lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org/docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
 </description>
         <guid>https://www.keycloak.org/2021/05/keycloak-1300-released</guid>
         <pubDate>Thu, 6 May 2021 00:00:00 GMT</pubDate>
@@ -617,7 +617,7 @@
       <item>
         <title>Keycloak 12.0.4 released</title>
         <link>https://www.keycloak.org/2021/03/keycloak-1204-released</link>
-        <description>&lt;p&gt;To download the release go to &lt;a href=&quot;https://www.keycloak.org//downloads.html&quot;&gt;Keycloak downloads&lt;/a&gt;.&lt;/p&gt;
+        <description>&lt;p&gt;To download the release go to &lt;a href=&quot;https://www.keycloak.org/downloads.html&quot;&gt;Keycloak downloads&lt;/a&gt;.&lt;/p&gt;
 
 &lt;div class=&quot;sect1&quot;&gt;
 &lt;h2 id=&quot;_highlights&quot;&gt;Highlights&lt;/h2&gt;
@@ -637,7 +637,7 @@
 &lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
 
 &lt;h2&gt;Upgrading&lt;/h2&gt;
-&lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org//docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
+&lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org/docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
 </description>
         <guid>https://www.keycloak.org/2021/03/keycloak-1204-released</guid>
         <pubDate>Mon, 1 Mar 2021 00:00:00 GMT</pubDate>
@@ -647,7 +647,7 @@
       <item>
         <title>Keycloak 12.0.3 released</title>
         <link>https://www.keycloak.org/2021/02/keycloak-1203-released</link>
-        <description>&lt;p&gt;To download the release go to &lt;a href=&quot;https://www.keycloak.org//downloads.html&quot;&gt;Keycloak downloads&lt;/a&gt;.&lt;/p&gt;
+        <description>&lt;p&gt;To download the release go to &lt;a href=&quot;https://www.keycloak.org/downloads.html&quot;&gt;Keycloak downloads&lt;/a&gt;.&lt;/p&gt;
 
 &lt;div class=&quot;sect1&quot;&gt;
 &lt;h2 id=&quot;_highlights&quot;&gt;Highlights&lt;/h2&gt;
@@ -667,7 +667,7 @@
 &lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
 
 &lt;h2&gt;Upgrading&lt;/h2&gt;
-&lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org//docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
+&lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org/docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
 </description>
         <guid>https://www.keycloak.org/2021/02/keycloak-1203-released</guid>
         <pubDate>Tue, 16 Feb 2021 00:00:00 GMT</pubDate>
@@ -677,7 +677,7 @@
       <item>
         <title>Keycloak 12.0.2 released</title>
         <link>https://www.keycloak.org/2021/01/keycloak-1202-released</link>
-        <description>&lt;p&gt;To download the release go to &lt;a href=&quot;https://www.keycloak.org//downloads.html&quot;&gt;Keycloak downloads&lt;/a&gt;.&lt;/p&gt;
+        <description>&lt;p&gt;To download the release go to &lt;a href=&quot;https://www.keycloak.org/downloads.html&quot;&gt;Keycloak downloads&lt;/a&gt;.&lt;/p&gt;
 
 &lt;div class=&quot;sect1&quot;&gt;
 &lt;h2 id=&quot;_highlights&quot;&gt;Highlights&lt;/h2&gt;
@@ -697,7 +697,7 @@
 &lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
 
 &lt;h2&gt;Upgrading&lt;/h2&gt;
-&lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org//docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
+&lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org/docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
 </description>
         <guid>https://www.keycloak.org/2021/01/keycloak-1202-released</guid>
         <pubDate>Tue, 19 Jan 2021 00:00:00 GMT</pubDate>
@@ -707,7 +707,7 @@
       <item>
         <title>Keycloak 12.0.1 released</title>
         <link>https://www.keycloak.org/2020/12/keycloak-1201-released</link>
-        <description>&lt;p&gt;To download the release go to &lt;a href=&quot;https://www.keycloak.org//downloads.html&quot;&gt;Keycloak downloads&lt;/a&gt;.&lt;/p&gt;
+        <description>&lt;p&gt;To download the release go to &lt;a href=&quot;https://www.keycloak.org/downloads.html&quot;&gt;Keycloak downloads&lt;/a&gt;.&lt;/p&gt;
 
 &lt;div class=&quot;sect1&quot;&gt;
 &lt;h2 id=&quot;_highlights&quot;&gt;Highlights&lt;/h2&gt;
@@ -727,7 +727,7 @@
 &lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
 
 &lt;h2&gt;Upgrading&lt;/h2&gt;
-&lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org//docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
+&lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org/docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
 </description>
         <guid>https://www.keycloak.org/2020/12/keycloak-1201-released</guid>
         <pubDate>Fri, 18 Dec 2020 00:00:00 GMT</pubDate>
@@ -1304,7 +1304,7 @@ you run the &lt;code&gt;config&lt;/code&gt; command to install your custom provi
       <item>
         <title>Keycloak 12.0.0 released</title>
         <link>https://www.keycloak.org/2020/12/keycloak-1200-released</link>
-        <description>&lt;p&gt;To download the release go to &lt;a href=&quot;https://www.keycloak.org//downloads.html&quot;&gt;Keycloak downloads&lt;/a&gt;.&lt;/p&gt;
+        <description>&lt;p&gt;To download the release go to &lt;a href=&quot;https://www.keycloak.org/downloads.html&quot;&gt;Keycloak downloads&lt;/a&gt;.&lt;/p&gt;
 
 &lt;div class=&quot;sect1&quot;&gt;
 &lt;h2 id=&quot;_highlights&quot;&gt;Highlights&lt;/h2&gt;
@@ -1324,7 +1324,7 @@ you run the &lt;code&gt;config&lt;/code&gt; command to install your custom provi
 &lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
 
 &lt;h2&gt;Upgrading&lt;/h2&gt;
-&lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org//docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
+&lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org/docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
 </description>
         <guid>https://www.keycloak.org/2020/12/keycloak-1200-released</guid>
         <pubDate>Wed, 16 Dec 2020 00:00:00 GMT</pubDate>
@@ -1334,7 +1334,7 @@ you run the &lt;code&gt;config&lt;/code&gt; command to install your custom provi
       <item>
         <title>Keycloak 11.0.3 released</title>
         <link>https://www.keycloak.org/2020/11/keycloak-1103-released</link>
-        <description>&lt;p&gt;To download the release go to &lt;a href=&quot;https://www.keycloak.org//downloads.html&quot;&gt;Keycloak downloads&lt;/a&gt;.&lt;/p&gt;
+        <description>&lt;p&gt;To download the release go to &lt;a href=&quot;https://www.keycloak.org/downloads.html&quot;&gt;Keycloak downloads&lt;/a&gt;.&lt;/p&gt;
 
 &lt;div class=&quot;sect1&quot;&gt;
 &lt;h2 id=&quot;_highlights&quot;&gt;Highlights&lt;/h2&gt;
@@ -1354,7 +1354,7 @@ you run the &lt;code&gt;config&lt;/code&gt; command to install your custom provi
 &lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
 
 &lt;h2&gt;Upgrading&lt;/h2&gt;
-&lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org//docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
+&lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org/docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
 </description>
         <guid>https://www.keycloak.org/2020/11/keycloak-1103-released</guid>
         <pubDate>Thu, 5 Nov 2020 00:00:00 GMT</pubDate>
@@ -1377,13 +1377,13 @@ you run the &lt;code&gt;config&lt;/code&gt; command to install your custom provi
 &lt;h2 id=&quot;_screen_shots_of_new_account_management_console&quot;&gt;Screen shots of New Account Management Console&lt;/h2&gt;
 &lt;div class=&quot;sectionbody&quot;&gt;
 &lt;div class=&quot;paragraph&quot;&gt;
-&lt;p&gt;&lt;span class=&quot;image&quot;&gt;&lt;img src=&quot;https://www.keycloak.org//resources/images/blog/new-account-console/welcome-screen.png&quot; alt=&quot;alt&quot;&gt;&lt;/span&gt;&lt;/p&gt;
+&lt;p&gt;&lt;span class=&quot;image&quot;&gt;&lt;img src=&quot;https://www.keycloak.org/resources/images/blog/new-account-console/welcome-screen.png&quot; alt=&quot;alt&quot;&gt;&lt;/span&gt;&lt;/p&gt;
 &lt;/div&gt;
 &lt;div class=&quot;paragraph&quot;&gt;
-&lt;p&gt;&lt;span class=&quot;image&quot;&gt;&lt;img src=&quot;https://www.keycloak.org//resources/images/blog/new-account-console/main-screen.png&quot; alt=&quot;alt&quot;&gt;&lt;/span&gt;&lt;/p&gt;
+&lt;p&gt;&lt;span class=&quot;image&quot;&gt;&lt;img src=&quot;https://www.keycloak.org/resources/images/blog/new-account-console/main-screen.png&quot; alt=&quot;alt&quot;&gt;&lt;/span&gt;&lt;/p&gt;
 &lt;/div&gt;
 &lt;div class=&quot;paragraph&quot;&gt;
-&lt;p&gt;&lt;span class=&quot;image&quot;&gt;&lt;img src=&quot;https://www.keycloak.org//resources/images/blog/new-account-console/device-activity.png&quot; alt=&quot;alt&quot;&gt;&lt;/span&gt;&lt;/p&gt;
+&lt;p&gt;&lt;span class=&quot;image&quot;&gt;&lt;img src=&quot;https://www.keycloak.org/resources/images/blog/new-account-console/device-activity.png&quot; alt=&quot;alt&quot;&gt;&lt;/span&gt;&lt;/p&gt;
 &lt;/div&gt;
 &lt;/div&gt;
 &lt;/div&gt;
@@ -1404,7 +1404,7 @@ you run the &lt;code&gt;config&lt;/code&gt; command to install your custom provi
 &lt;/div&gt;
 &lt;/div&gt;
 &lt;div class=&quot;paragraph&quot;&gt;
-&lt;p&gt;&lt;span class=&quot;image&quot;&gt;&lt;img src=&quot;https://www.keycloak.org//resources/images/blog/new-account-console/keycloak-man-welcome-screen.png&quot; alt=&quot;alt&quot;&gt;&lt;/span&gt;&lt;/p&gt;
+&lt;p&gt;&lt;span class=&quot;image&quot;&gt;&lt;img src=&quot;https://www.keycloak.org/resources/images/blog/new-account-console/keycloak-man-welcome-screen.png&quot; alt=&quot;alt&quot;&gt;&lt;/span&gt;&lt;/p&gt;
 &lt;/div&gt;
 &lt;/div&gt;
 &lt;/div&gt;
@@ -1418,13 +1418,13 @@ you run the &lt;code&gt;config&lt;/code&gt; command to install your custom provi
 &lt;p&gt;It&amp;#8217;s even possible to build new pages with nothing but an editor.  No build step is required unless you want to use more advanced tools like JSX and Typescript.&lt;/p&gt;
 &lt;/div&gt;
 &lt;div class=&quot;paragraph&quot;&gt;
-&lt;p&gt;&lt;span class=&quot;image&quot;&gt;&lt;img src=&quot;https://www.keycloak.org//resources/images/blog/new-account-console/who-is-keycloak-man.png&quot; alt=&quot;alt&quot;&gt;&lt;/span&gt;&lt;/p&gt;
+&lt;p&gt;&lt;span class=&quot;image&quot;&gt;&lt;img src=&quot;https://www.keycloak.org/resources/images/blog/new-account-console/who-is-keycloak-man.png&quot; alt=&quot;alt&quot;&gt;&lt;/span&gt;&lt;/p&gt;
 &lt;/div&gt;
 &lt;div class=&quot;paragraph&quot;&gt;
-&lt;p&gt;&lt;span class=&quot;image&quot;&gt;&lt;img src=&quot;https://www.keycloak.org//resources/images/blog/new-account-console/keycloak-man-overview.png&quot; alt=&quot;alt&quot;&gt;&lt;/span&gt;&lt;/p&gt;
+&lt;p&gt;&lt;span class=&quot;image&quot;&gt;&lt;img src=&quot;https://www.keycloak.org/resources/images/blog/new-account-console/keycloak-man-overview.png&quot; alt=&quot;alt&quot;&gt;&lt;/span&gt;&lt;/p&gt;
 &lt;/div&gt;
 &lt;div class=&quot;paragraph&quot;&gt;
-&lt;p&gt;&lt;span class=&quot;image&quot;&gt;&lt;img src=&quot;https://www.keycloak.org//resources/images/blog/new-account-console/keycloak-man-jsx.png&quot; alt=&quot;alt&quot;&gt;&lt;/span&gt;&lt;/p&gt;
+&lt;p&gt;&lt;span class=&quot;image&quot;&gt;&lt;img src=&quot;https://www.keycloak.org/resources/images/blog/new-account-console/keycloak-man-jsx.png&quot; alt=&quot;alt&quot;&gt;&lt;/span&gt;&lt;/p&gt;
 &lt;/div&gt;
 &lt;div class=&quot;paragraph&quot;&gt;
 &lt;p&gt;Of course, this &quot;Keycloak Man&quot; theme is available online as a Keycloak Quick Start so you can check out all the source.&lt;/p&gt;
@@ -1447,7 +1447,7 @@ you run the &lt;code&gt;config&lt;/code&gt; command to install your custom provi
       <item>
         <title>Keycloak 11.0.2 released</title>
         <link>https://www.keycloak.org/2020/08/keycloak-1102-released</link>
-        <description>&lt;p&gt;To download the release go to &lt;a href=&quot;https://www.keycloak.org//downloads.html&quot;&gt;Keycloak downloads&lt;/a&gt;.&lt;/p&gt;
+        <description>&lt;p&gt;To download the release go to &lt;a href=&quot;https://www.keycloak.org/downloads.html&quot;&gt;Keycloak downloads&lt;/a&gt;.&lt;/p&gt;
 
 &lt;div class=&quot;sect1&quot;&gt;
 &lt;h2 id=&quot;_highlights&quot;&gt;Highlights&lt;/h2&gt;
@@ -1467,7 +1467,7 @@ you run the &lt;code&gt;config&lt;/code&gt; command to install your custom provi
 &lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
 
 &lt;h2&gt;Upgrading&lt;/h2&gt;
-&lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org//docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
+&lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org/docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
 </description>
         <guid>https://www.keycloak.org/2020/08/keycloak-1102-released</guid>
         <pubDate>Mon, 31 Aug 2020 00:00:00 GMT</pubDate>
@@ -1538,7 +1538,7 @@ you run the &lt;code&gt;config&lt;/code&gt; command to install your custom provi
       <item>
         <title>Keycloak 11.0.1 released</title>
         <link>https://www.keycloak.org/2020/08/keycloak-1101-released</link>
-        <description>&lt;p&gt;To download the release go to &lt;a href=&quot;https://www.keycloak.org//downloads.html&quot;&gt;Keycloak downloads&lt;/a&gt;.&lt;/p&gt;
+        <description>&lt;p&gt;To download the release go to &lt;a href=&quot;https://www.keycloak.org/downloads.html&quot;&gt;Keycloak downloads&lt;/a&gt;.&lt;/p&gt;
 
 &lt;div class=&quot;sect1&quot;&gt;
 &lt;h2 id=&quot;_highlights&quot;&gt;Highlights&lt;/h2&gt;
@@ -1558,7 +1558,7 @@ you run the &lt;code&gt;config&lt;/code&gt; command to install your custom provi
 &lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
 
 &lt;h2&gt;Upgrading&lt;/h2&gt;
-&lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org//docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
+&lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org/docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
 </description>
         <guid>https://www.keycloak.org/2020/08/keycloak-1101-released</guid>
         <pubDate>Fri, 21 Aug 2020 00:00:00 GMT</pubDate>
@@ -1568,7 +1568,7 @@ you run the &lt;code&gt;config&lt;/code&gt; command to install your custom provi
       <item>
         <title>Keycloak 11.0.0 released</title>
         <link>https://www.keycloak.org/2020/07/keycloak-1100-released</link>
-        <description>&lt;p&gt;To download the release go to &lt;a href=&quot;https://www.keycloak.org//downloads.html&quot;&gt;Keycloak downloads&lt;/a&gt;.&lt;/p&gt;
+        <description>&lt;p&gt;To download the release go to &lt;a href=&quot;https://www.keycloak.org/downloads.html&quot;&gt;Keycloak downloads&lt;/a&gt;.&lt;/p&gt;
 
 &lt;div class=&quot;sect1&quot;&gt;
 &lt;h2 id=&quot;_highlights&quot;&gt;Highlights&lt;/h2&gt;
@@ -1588,7 +1588,7 @@ you run the &lt;code&gt;config&lt;/code&gt; command to install your custom provi
 &lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
 
 &lt;h2&gt;Upgrading&lt;/h2&gt;
-&lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org//docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
+&lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org/docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
 </description>
         <guid>https://www.keycloak.org/2020/07/keycloak-1100-released</guid>
         <pubDate>Wed, 22 Jul 2020 00:00:00 GMT</pubDate>
@@ -1598,7 +1598,7 @@ you run the &lt;code&gt;config&lt;/code&gt; command to install your custom provi
       <item>
         <title>Keycloak 10.0.2 released</title>
         <link>https://www.keycloak.org/2020/06/keycloak-1002-released</link>
-        <description>&lt;p&gt;To download the release go to &lt;a href=&quot;https://www.keycloak.org//downloads.html&quot;&gt;Keycloak downloads&lt;/a&gt;.&lt;/p&gt;
+        <description>&lt;p&gt;To download the release go to &lt;a href=&quot;https://www.keycloak.org/downloads.html&quot;&gt;Keycloak downloads&lt;/a&gt;.&lt;/p&gt;
 
 &lt;div class=&quot;sect1&quot;&gt;
 &lt;h2 id=&quot;_highlights&quot;&gt;Highlights&lt;/h2&gt;
@@ -1618,7 +1618,7 @@ you run the &lt;code&gt;config&lt;/code&gt; command to install your custom provi
 &lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
 
 &lt;h2&gt;Upgrading&lt;/h2&gt;
-&lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org//docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
+&lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org/docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
 </description>
         <guid>https://www.keycloak.org/2020/06/keycloak-1002-released</guid>
         <pubDate>Tue, 2 Jun 2020 00:00:00 GMT</pubDate>
@@ -1628,7 +1628,7 @@ you run the &lt;code&gt;config&lt;/code&gt; command to install your custom provi
       <item>
         <title>Keycloak 10.0.1 released</title>
         <link>https://www.keycloak.org/2020/05/keycloak-1001-released</link>
-        <description>&lt;p&gt;To download the release go to &lt;a href=&quot;https://www.keycloak.org//downloads.html&quot;&gt;Keycloak downloads&lt;/a&gt;.&lt;/p&gt;
+        <description>&lt;p&gt;To download the release go to &lt;a href=&quot;https://www.keycloak.org/downloads.html&quot;&gt;Keycloak downloads&lt;/a&gt;.&lt;/p&gt;
 
 &lt;div class=&quot;sect1&quot;&gt;
 &lt;h2 id=&quot;_highlights&quot;&gt;Highlights&lt;/h2&gt;
@@ -1648,7 +1648,7 @@ you run the &lt;code&gt;config&lt;/code&gt; command to install your custom provi
 &lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
 
 &lt;h2&gt;Upgrading&lt;/h2&gt;
-&lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org//docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
+&lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org/docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
 </description>
         <guid>https://www.keycloak.org/2020/05/keycloak-1001-released</guid>
         <pubDate>Fri, 8 May 2020 00:00:00 GMT</pubDate>
@@ -1658,7 +1658,7 @@ you run the &lt;code&gt;config&lt;/code&gt; command to install your custom provi
       <item>
         <title>Keycloak 10.0.0 released</title>
         <link>https://www.keycloak.org/2020/04/keycloak-1000-released</link>
-        <description>&lt;p&gt;To download the release go to &lt;a href=&quot;https://www.keycloak.org//downloads.html&quot;&gt;Keycloak downloads&lt;/a&gt;.&lt;/p&gt;
+        <description>&lt;p&gt;To download the release go to &lt;a href=&quot;https://www.keycloak.org/downloads.html&quot;&gt;Keycloak downloads&lt;/a&gt;.&lt;/p&gt;
 
 &lt;div class=&quot;sect1&quot;&gt;
 &lt;h2 id=&quot;_highlights&quot;&gt;Highlights&lt;/h2&gt;
@@ -1678,7 +1678,7 @@ you run the &lt;code&gt;config&lt;/code&gt; command to install your custom provi
 &lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
 
 &lt;h2&gt;Upgrading&lt;/h2&gt;
-&lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org//docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
+&lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org/docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
 </description>
         <guid>https://www.keycloak.org/2020/04/keycloak-1000-released</guid>
         <pubDate>Wed, 29 Apr 2020 00:00:00 GMT</pubDate>
@@ -1708,7 +1708,7 @@ from users of Keycloak in order to make the new admin console as good as it can 
       <item>
         <title>Keycloak 9.0.3 released</title>
         <link>https://www.keycloak.org/2020/04/keycloak-903-released</link>
-        <description>&lt;p&gt;To download the release go to &lt;a href=&quot;https://www.keycloak.org//downloads.html&quot;&gt;Keycloak downloads&lt;/a&gt;.&lt;/p&gt;
+        <description>&lt;p&gt;To download the release go to &lt;a href=&quot;https://www.keycloak.org/downloads.html&quot;&gt;Keycloak downloads&lt;/a&gt;.&lt;/p&gt;
 
 &lt;div class=&quot;sect1&quot;&gt;
 &lt;h2 id=&quot;_highlights&quot;&gt;Highlights&lt;/h2&gt;
@@ -1728,7 +1728,7 @@ from users of Keycloak in order to make the new admin console as good as it can 
 &lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
 
 &lt;h2&gt;Upgrading&lt;/h2&gt;
-&lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org//docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
+&lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org/docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
 </description>
         <guid>https://www.keycloak.org/2020/04/keycloak-903-released</guid>
         <pubDate>Tue, 14 Apr 2020 00:00:00 GMT</pubDate>
@@ -1738,7 +1738,7 @@ from users of Keycloak in order to make the new admin console as good as it can 
       <item>
         <title>Keycloak 9.0.2 released</title>
         <link>https://www.keycloak.org/2020/03/keycloak-902-released</link>
-        <description>&lt;p&gt;To download the release go to &lt;a href=&quot;https://www.keycloak.org//downloads.html&quot;&gt;Keycloak downloads&lt;/a&gt;.&lt;/p&gt;
+        <description>&lt;p&gt;To download the release go to &lt;a href=&quot;https://www.keycloak.org/downloads.html&quot;&gt;Keycloak downloads&lt;/a&gt;.&lt;/p&gt;
 
 &lt;div class=&quot;sect1&quot;&gt;
 &lt;h2 id=&quot;_highlights&quot;&gt;Highlights&lt;/h2&gt;
@@ -1758,7 +1758,7 @@ from users of Keycloak in order to make the new admin console as good as it can 
 &lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
 
 &lt;h2&gt;Upgrading&lt;/h2&gt;
-&lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org//docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
+&lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org/docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
 </description>
         <guid>https://www.keycloak.org/2020/03/keycloak-902-released</guid>
         <pubDate>Tue, 24 Mar 2020 00:00:00 GMT</pubDate>
@@ -1768,7 +1768,7 @@ from users of Keycloak in order to make the new admin console as good as it can 
       <item>
         <title>Keycloak 9.0.0 released</title>
         <link>https://www.keycloak.org/2020/02/keycloak-900-released</link>
-        <description>&lt;p&gt;To download the release go to &lt;a href=&quot;https://www.keycloak.org//downloads.html&quot;&gt;Keycloak downloads&lt;/a&gt;.&lt;/p&gt;
+        <description>&lt;p&gt;To download the release go to &lt;a href=&quot;https://www.keycloak.org/downloads.html&quot;&gt;Keycloak downloads&lt;/a&gt;.&lt;/p&gt;
 
 &lt;div class=&quot;sect1&quot;&gt;
 &lt;h2 id=&quot;_highlights&quot;&gt;Highlights&lt;/h2&gt;
@@ -1788,7 +1788,7 @@ from users of Keycloak in order to make the new admin console as good as it can 
 &lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
 
 &lt;h2&gt;Upgrading&lt;/h2&gt;
-&lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org//docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
+&lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org/docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
 </description>
         <guid>https://www.keycloak.org/2020/02/keycloak-900-released</guid>
         <pubDate>Mon, 17 Feb 2020 00:00:00 GMT</pubDate>
@@ -2111,14 +2111,14 @@ ADD cli/JDBC_PING.cli /opt/jboss/tools/cli/jgroups/discovery/
 &lt;h3&gt;1. PING&lt;/h3&gt;
 &lt;p&gt;&lt;a href=&quot;http://jgroups.org/manual/#PING&quot;&gt;PING&lt;/a&gt; is the default enabled clustering solution of Keycloak using UDP protocol, and you don&#39;t need to do any configuration for this.&lt;/p&gt;
 &lt;p&gt;But PING is only available when multicast network is enabled and port 55200 should be exposed, e.g. bare metals, VMs, docker containers in the same host.&lt;/p&gt;
-&lt;img src=&quot;https://www.keycloak.org//resources/images/blog/cluster-setup/ping-deployment.jpg&quot;/&gt;
+&lt;img src=&quot;https://www.keycloak.org/resources/images/blog/cluster-setup/ping-deployment.jpg&quot;/&gt;
 &lt;p&gt;We tested this by two Keycloak containers in same host.&lt;/p&gt;
 &lt;p&gt;The logs show that the two Keycloak instances discovered each other and clustered.&lt;/p&gt;
-&lt;img src=&quot;https://www.keycloak.org//resources/images/blog/cluster-setup/ping-log.png&quot;/&gt;
+&lt;img src=&quot;https://www.keycloak.org/resources/images/blog/cluster-setup/ping-log.png&quot;/&gt;
 
 &lt;h3&gt;2. TCPPING&lt;/h3&gt;
 &lt;p&gt;&lt;a href=&quot;http://jgroups.org/manual/#TCPPING_Prot&quot;&gt;TCPPING&lt;/a&gt; use TCP protocol with 7600 port. This can be used when multicast is not available, e.g. deployments cross DC, containers cross host.&lt;/p&gt;
-&lt;img src=&quot;https://www.keycloak.org//resources/images/blog/cluster-setup/tcp-ping-deployment.jpg&quot;/&gt;
+&lt;img src=&quot;https://www.keycloak.org/resources/images/blog/cluster-setup/tcp-ping-deployment.jpg&quot;/&gt;
 &lt;p&gt;We tested this by two Keycloak containers cross host.&lt;/p&gt;
 &lt;p&gt;And in this solution we need to set three below environment variables for containers.
 &lt;pre&gt;
@@ -2131,7 +2131,7 @@ JGROUPS_DISCOVERY_PROPERTIES=initial_hosts=&quot;172.21.48.4[7600],172.21.48.39[
 &lt;/pre&gt;
 &lt;/p&gt;
 &lt;p&gt;The logs show that the two Keycloak instances discovered each other and clustered.&lt;/p&gt;
-&lt;img src=&quot;https://www.keycloak.org//resources/images/blog/cluster-setup/tcp-ping-log.png&quot;/&gt;
+&lt;img src=&quot;https://www.keycloak.org/resources/images/blog/cluster-setup/tcp-ping-log.png&quot;/&gt;
 
 &lt;h3&gt;3. JDBC_PING&lt;/h3&gt;
 &lt;p&gt;&lt;a href=&quot;http://jgroups.org/manual/#_jdbc_ping&quot;&gt;JDBC_PING&lt;/a&gt; use TCP protocol with 7600 port which is similar as TCPPING, but the difference between them is, TCPPING requires you configure the IP and port of all instances,  for JDBC_PING you just need to configure the IP and port of current instance, this is because in JDBC_PING solution each instance insert its own information into database and the instances discover peers by the ping data read from database.&lt;/p&gt;
@@ -2145,9 +2145,9 @@ JGROUPS_DISCOVERY_PROTOCOL=JDBC_PING
 &lt;/pre&gt;
 &lt;/p&gt;
 &lt;p&gt;The ping data of all instances haven been saved in database after instances started.&lt;/p&gt;
-&lt;img src=&quot;https://www.keycloak.org//resources/images/blog/cluster-setup/jdbc-ping-data.png&quot;/&gt;
+&lt;img src=&quot;https://www.keycloak.org/resources/images/blog/cluster-setup/jdbc-ping-data.png&quot;/&gt;
 &lt;p&gt;The logs show that the two Keycloak instances discovered each other and clustered.&lt;/p&gt;
-&lt;img src=&quot;https://www.keycloak.org//resources/images/blog/cluster-setup/jdbc-ping-log.png&quot;/&gt;
+&lt;img src=&quot;https://www.keycloak.org/resources/images/blog/cluster-setup/jdbc-ping-log.png&quot;/&gt;
 
 &lt;h3&gt;One more thing&lt;/h3&gt;
 &lt;p&gt;The above solutions are available for most scenarios, but they are still not enough for some others, e.g.Kubernetes.&lt;/p&gt;
@@ -2492,7 +2492,7 @@ This will be included in Keycloak 4.1.0.Final which will be released soon. In th
 
 &lt;p&gt;With Javascript application, whole OpenID Connect login flow happens within browser and hence can rely on sticky session. So since Javascript adapter is used, you may think that we can do just &quot;easy&quot; setup and let the RH-SSO instances across all 3 clouds to be independent of each other and have each of them to use separate RDBMS and infinispan caches. See the image below  for what such a setup would look like:
 
-&lt;img src=&quot;https://www.keycloak.org//resources/images/blog/cross-dc-blog-architecture-rhsso.png&quot; /&gt;
+&lt;img src=&quot;https://www.keycloak.org/resources/images/blog/cross-dc-blog-architecture-rhsso.png&quot; /&gt;
 
 &lt;p&gt;With this setup, every cloud is aware just about the users and sessions created on itself. This is fine with sticky session, but it won’t work for failover scenarios in case if one of the 3 clouds is broken/removed. There are also other issues with it - for example that admins and users see just sessions created on particular cloud. There are also potential security issues. For example when admin disables user on one cloud, user would still be enabled on other clouds as changes to user won’t be propagated to other clouds.
 
@@ -2500,7 +2500,7 @@ This will be included in Keycloak 4.1.0.Final which will be released soon. In th
 
 &lt;p&gt;In Keycloak 3.X, we added support for &lt;a href=&quot;https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.2/html/server_installation_and_configuration_guide/operating-mode#crossdc-mode&quot;&gt;Cross-datacenter (Cross-site) setup&lt;/a&gt; with usage of external JDG servers to replicate data among datacenters (tech preview in RH-SSO 7.2). The demo was using exactly this setup. Each site had JDG server and all 3 sites communicate with each other through those JDG servers. This is standard JDG Cross-DC setup. See the picture below for what the demo looked like:
 
-&lt;img src=&quot;https://www.keycloak.org//resources/images/blog/cross-dc-blog-actual-setup-architecture-rhsso.png&quot; /&gt;
+&lt;img src=&quot;https://www.keycloak.org/resources/images/blog/cross-dc-blog-actual-setup-architecture-rhsso.png&quot; /&gt;
 
 &lt;p&gt;The JDG servers were not used during the demo just for the purpose of the RH-SSO, but also for the purpose of other parts of the demo. The details are described in the &lt;a href=&quot;https://developers.redhat.com/blog/2018/06/19/red-hat-data-grid-on-three-clouds/&quot;&gt;JDG setup blog by  Sebastian Łaskawiec&lt;/a&gt;. The JDG servers were setup with ASYNC backups, which was more effective and was completely fine for the purpose of the demo due the fact that mobile application was using keycloak.js adapter. See &lt;a href=&quot;https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.2/html/server_installation_and_configuration_guide/operating-mode#backups&quot;&gt;RH-SSO docs&lt;/a&gt; for more details.
 
@@ -2520,7 +2520,7 @@ This will be included in Keycloak 4.1.0.Final which will be released soon. In th
 
 &lt;p&gt;For the purpose of the demo, we did custom login theme. We also did Email-Only authenticator, which allows to register user just by providing their email address. This is obviously not very secure, but it&#39;s pretty neat for the example purpose. Keynote users were also able to login with &lt;a href=&quot;https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.2/html/server_administration_guide/identity_broker#google&quot;&gt;Google Identity Provider&lt;/a&gt;  or &lt;a href=&quot;https://developers.redhat.com/&quot;&gt;Red Hat Developers OpenID Connect Identity Provider&lt;/a&gt;, which was useful for users, who already had an account in those services.
 
-&lt;img src=&quot;https://www.keycloak.org//resources/images/blog/login-screen.png&quot; /&gt;
+&lt;img src=&quot;https://www.keycloak.org/resources/images/blog/login-screen.png&quot; /&gt;
 
 &lt;p&gt;If you want to try all these things in action, you can try to checkout our &lt;a href=&quot;https://github.com/rhdemo/rh-sso&quot;&gt;Demo Project on Github&lt;/a&gt; and deploy it to your own openshift cluster! If you have 3 clouds, even better! You can try the full setup including JDG to try exactly the setup we used during keynote demo.
 
@@ -2757,13 +2757,13 @@ You have now deployed and secured the application as well as seen how the applic
 
 &lt;p&gt;Envoy captures all incoming and outgoing traffic of its &quot;companion&quot; service, it can then apply some basic operations and also collect data and send it to a central point of decision, called the &quot;mixer&quot; in Istio. The conifugration of Envoy itself happens through the &quot;pilot&quot; an other Istio component.&lt;/p&gt;
 
-&lt;img src=&quot;https://www.keycloak.org//resources/images/blog/istio-architecture.png&quot;/&gt;&lt;div&gt;
+&lt;img src=&quot;https://www.keycloak.org/resources/images/blog/istio-architecture.png&quot;/&gt;&lt;div&gt;
 
 &lt;h3&gt;Envoy Filters&lt;/h3&gt;
 
 &lt;p&gt;To make it easier to add new functionnality to the Envoy Proxy, there is the concept of filters that you can stack up. Again, these filters can be congifured by the Pilot and they can gather information for the Mixer:&lt;/p&gt;
 
-&lt;img src=&quot;https://www.keycloak.org//resources/images/blog/envoydetails.png&quot; /&gt;
+&lt;img src=&quot;https://www.keycloak.org/resources/images/blog/envoydetails.png&quot; /&gt;
 
 &lt;h3&gt;The JWT-Auth Filter&lt;/h3&gt;
 
@@ -2775,7 +2775,7 @@ You have now deployed and secured the application as well as seen how the applic
 
 &lt;p&gt;Now that you have the big picture in mind let&#39;s take a look at the demo that has been developed by Kamesh Sampath (@kamesh_sampath) From the Red Hat Developer Experience Team to show how Keycloak and Istio can be combined:&lt;/p&gt;
 
-&lt;img src=&quot;https://www.keycloak.org//resources/images/blog/bigpicure1.png&quot;/&gt;
+&lt;img src=&quot;https://www.keycloak.org/resources/images/blog/bigpicure1.png&quot;/&gt;
 
 &lt;p&gt;The demo will be running inside a Minishift instance, Minishift is a tool that helps to run OpenShift locally. Minishift has really nice support for Istio, as it takes only a few commands to install the Istio layer inside a Minishift instance.&lt;/p&gt;
 
@@ -2800,7 +2800,7 @@ You have now deployed and secured the application as well as seen how the applic
 
 &lt;p&gt;Thi is how the Cars API Pod looks like after it is deployed:&lt;/p&gt;
 
-&lt;img src=&quot;https://www.keycloak.org//resources/images/blog/carsapipod.png&quot; /&gt;
+&lt;img src=&quot;https://www.keycloak.org/resources/images/blog/carsapipod.png&quot; /&gt;
 
 &lt;p&gt;Now, the Envoy Sidecar needs to be configured:&lt;/p&gt;
 
@@ -2810,7 +2810,7 @@ You have now deployed and secured the application as well as seen how the applic
 &lt;li&gt;The issuer : who has generated the token ? In this case it&#39;s also the Keycloak Server.&lt;/li&gt;
 &lt;/ul&gt;
 
-&lt;img src=&quot;https://www.keycloak.org//resources/images/blog/pilotscript.png&quot; /&gt;
+&lt;img src=&quot;https://www.keycloak.org/resources/images/blog/pilotscript.png&quot; /&gt;
 
 &lt;p&gt;Now each incoming request to the API Service will be checked by the Envoy Sidecar to see if the JWT token contained in the header is valid or not. If it&#39;s valid the request be authorized otherwise an error message will be returned.&lt;/p&gt;
 
@@ -2846,7 +2846,7 @@ ng generate keycloak --collection @ssilvert/keycloak-schematic --clientId=myApp
 
 &lt;p&gt;Go to your browser to start the app and see this:&lt;/p&gt;
 
-&lt;img src=&quot;https://www.keycloak.org//resources/images/blog/login.png&quot;/&gt;
+&lt;img src=&quot;https://www.keycloak.org/resources/images/blog/login.png&quot;/&gt;
 
 &lt;p&gt;Oh joy! myApp is protected with Keycloak!&lt;/p&gt;
 
@@ -3830,7 +3830,7 @@ For more details see &lt;a href=&quot;https://access.redhat.com/security/cve/cve
 &lt;b id=&quot;docs-internal-guid-d7a78233-f66d-5bde-d887-549caec7811b&quot; style=&quot;font-weight: normal;&quot;&gt;&lt;br /&gt;&lt;/b&gt;
 &lt;br /&gt;
 &lt;div style=&quot;margin-bottom: 0pt; margin-top: 0pt; text-align: center;&quot;&gt;
-&lt;span&gt;&lt;img height=&quot;640&quot; src=&quot;https://www.keycloak.org//resources/images/blog/adfs/0-adfs.png&quot; width=&quot;617&quot; /&gt;&lt;/span&gt;&lt;/div&gt;
+&lt;span&gt;&lt;img height=&quot;640&quot; src=&quot;https://www.keycloak.org/resources/images/blog/adfs/0-adfs.png&quot; width=&quot;617&quot; /&gt;&lt;/span&gt;&lt;/div&gt;
 &lt;h3 style=&quot;margin-bottom: 4pt; margin-top: 16pt;&quot;&gt;
 &lt;span style=&quot;color: #434343; font-size: 14pt; white-space: pre-wrap;&quot;&gt;Setup Mappers&lt;/span&gt;&lt;/h3&gt;
 &lt;p&gt;&lt;span&gt;In the steps setting AD FS below, AD FS will be set up to send email and group information in SAML assertion. To transform these details from SAML document issued by AD FS to Keycloak user store, we’ll need to set up two corresponding mappers in the Mappers tab of Identity Provider:&lt;/span&gt;&lt;/p&gt;
@@ -3839,13 +3839,13 @@ For more details see &lt;a href=&quot;https://access.redhat.com/security/cve/cve
 &lt;/ul&gt;
 &lt;p&gt;&lt;span&gt;&lt;span class=&quot;Apple-tab-span&quot; style=&quot;white-space: pre;&quot;&gt; &lt;/span&gt;&lt;/span&gt;&lt;/p&gt;
 &lt;div style=&quot;margin-bottom: 0pt; margin-top: 0pt; text-align: center;&quot;&gt;
-&lt;span&gt;&lt;span class=&quot;Apple-tab-span&quot; style=&quot;white-space: pre;&quot;&gt; &lt;/span&gt;&lt;/span&gt;&lt;span&gt;&lt;img height=&quot;266&quot; src=&quot;https://www.keycloak.org//resources/images/blog/adfs/1-adfs.png&quot; width=&quot;400&quot; /&gt;&lt;/span&gt;&lt;/div&gt;
+&lt;span&gt;&lt;span class=&quot;Apple-tab-span&quot; style=&quot;white-space: pre;&quot;&gt; &lt;/span&gt;&lt;/span&gt;&lt;span&gt;&lt;img height=&quot;266&quot; src=&quot;https://www.keycloak.org/resources/images/blog/adfs/1-adfs.png&quot; width=&quot;400&quot; /&gt;&lt;/span&gt;&lt;/div&gt;
 &lt;br /&gt;
 &lt;ul&gt;
 &lt;li&gt;Mapper named &lt;/span&gt;&lt;span style=&quot;font-size: 11pt; font-style: italic&quot;&gt;Attribute: email&lt;/span&gt;&lt;span&gt; will be of type &lt;/span&gt;&lt;span style=&quot;font-size: 11pt; font-style: italic&quot;&gt;Attribute Importer&lt;/span&gt;&lt;span&gt;, and will map attribute named &lt;/span&gt;&lt;span style=&quot;font-size: 11pt; font-style: italic&quot;&gt;http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress&lt;/span&gt;&lt;span&gt; into user attribute named &lt;/span&gt;&lt;span style=&quot;font-size: 11pt; font-style: italic&quot;&gt;email&lt;/span&gt;&lt;span&gt;.&lt;/li&gt;
 &lt;/ul&gt;
 &lt;div style=&quot;margin-bottom: 0pt; margin-top: 0pt; text-align: center;&quot;&gt;
-&lt;span&gt;&lt;img height=&quot;200&quot; src=&quot;https://www.keycloak.org//resources/images/blog/adfs/2-adfs.png&quot; width=&quot;400&quot; /&gt;&lt;/span&gt;&lt;/div&gt;
+&lt;span&gt;&lt;img height=&quot;200&quot; src=&quot;https://www.keycloak.org/resources/images/blog/adfs/2-adfs.png&quot; width=&quot;400&quot; /&gt;&lt;/span&gt;&lt;/div&gt;
 &lt;h3 style=&quot;margin-bottom: 4pt; margin-top: 16pt;&quot;&gt;
 &lt;span style=&quot;color: #434343; font-size: 14pt; white-space: pre-wrap;&quot;&gt;Obtain information for the AD FS configuration&lt;/span&gt;&lt;/h3&gt;
 &lt;p&gt;&lt;span&gt;Now we determine SAML service provider descriptor URI that will be used in AD FS setup from the &lt;/span&gt;&lt;span style=&quot;font-size: 11pt; font-style: italic&quot;&gt;Redirect URI&lt;/span&gt;&lt;span&gt; field in the identity provider detail by adding “/descriptor” to the URI in this field. The URI will be similar to &lt;/span&gt;&lt;span style=&quot;font-weight: 700&quot;&gt;https://kc.domain.name:8443/auth/realms/master/broker/adfs-idp-alias/endpoint/descriptor&lt;/span&gt;&lt;span&gt;. You can check whether you got the URI right by entering the URI into the browser - you should receive a SAML service provider XML descriptor.&lt;/span&gt;&lt;/p&gt;
@@ -3856,7 +3856,7 @@ For more details see &lt;a href=&quot;https://access.redhat.com/security/cve/cve
 &lt;p&gt;&lt;span&gt;In AD FS Management console, right-click Tr&lt;/span&gt;&lt;span style=&quot;font-size: 11pt; font-style: italic&quot;&gt;ust relationships → Relying Party Trusts&lt;/span&gt;&lt;span&gt; and select &lt;/span&gt;&lt;span style=&quot;font-size: 11pt; font-style: italic&quot;&gt;Add Relying Party Trust&lt;/span&gt;&lt;span&gt; from the menu:&lt;/span&gt;&lt;/p&gt;
 &lt;br /&gt;
 &lt;div style=&quot;margin-bottom: 0pt; margin-top: 0pt; text-align: center;&quot;&gt;
-&lt;span&gt;&lt;img src=&quot;https://www.keycloak.org//resources/images/blog/adfs/3-adfs.png&quot; /&gt;&lt;/span&gt;&lt;/div&gt;
+&lt;span&gt;&lt;img src=&quot;https://www.keycloak.org/resources/images/blog/adfs/3-adfs.png&quot; /&gt;&lt;/span&gt;&lt;/div&gt;
 &lt;br /&gt;
 &lt;p&gt;&lt;span&gt;At the beginning of the wizard, enter the SAML descriptor URL obtained in the previous step into the &lt;/span&gt;&lt;span style=&quot;font-size: 11pt; font-style: italic&quot;&gt;Federation metadata address &lt;/span&gt;&lt;span&gt;field, and let AD FS import the settings. Proceed with the wizard, and adjust the settings where appropriate. Here we use only the default settings. Note that you will need to edit the claim rules so when asked to do so at the last page of the wizard, you can leave the checkbox checked on.&lt;/span&gt;&lt;/p&gt;
 &lt;h4 style=&quot;margin-bottom: 4pt; margin-top: 14pt;&quot;&gt;
@@ -3865,24 +3865,24 @@ For more details see &lt;a href=&quot;https://access.redhat.com/security/cve/cve
 &lt;p&gt;&lt;span&gt;We will set up three rules: one for mapping user ID, second for mapping standard user attributes, and third for a user group. All start by clicking the &lt;/span&gt;&lt;span style=&quot;font-size: 11pt; font-style: italic&quot;&gt;Add Rule&lt;/span&gt;&lt;span&gt; button in the &lt;/span&gt;&lt;span style=&quot;font-size: 11pt; font-style: italic&quot;&gt;Edit Claim Rules for kc.domain.name&lt;/span&gt;&lt;span&gt; window:&lt;/span&gt;&lt;/p&gt;
 &lt;br /&gt;
 &lt;div style=&quot;margin-bottom: 0pt; margin-top: 0pt; text-align: center;&quot;&gt;
-&lt;span&gt;&lt;img height=&quot;400&quot; src=&quot;https://www.keycloak.org//resources/images/blog/adfs/4-adfs.png&quot; width=&quot;365&quot; /&gt;&lt;/span&gt;&lt;/div&gt;
+&lt;span&gt;&lt;img height=&quot;400&quot; src=&quot;https://www.keycloak.org/resources/images/blog/adfs/4-adfs.png&quot; width=&quot;365&quot; /&gt;&lt;/span&gt;&lt;/div&gt;
 &lt;br /&gt;
 &lt;p&gt;&lt;span&gt;The first rule will map user ID in Windows Qualified Domain name to the SAML response. In the &lt;/span&gt;&lt;span style=&quot;font-size: 11pt; font-style: italic&quot;&gt;Add Transform Claim Rule&lt;/span&gt;&lt;span&gt; window, select &lt;/span&gt;&lt;span style=&quot;font-size: 11pt; font-style: italic&quot;&gt;Transform an incoming claim &lt;/span&gt;&lt;span&gt;rule type:&lt;/span&gt;&lt;/p&gt;
 &lt;br /&gt;
 &lt;div style=&quot;margin-bottom: 0pt; margin-top: 0pt; text-align: center;&quot;&gt;
-&lt;span&gt;&lt;img height=&quot;515&quot; src=&quot;https://www.keycloak.org//resources/images/blog/adfs/5-adfs.png&quot; width=&quot;640&quot; /&gt;&lt;/span&gt;&lt;/div&gt;
+&lt;span&gt;&lt;img height=&quot;515&quot; src=&quot;https://www.keycloak.org/resources/images/blog/adfs/5-adfs.png&quot; width=&quot;640&quot; /&gt;&lt;/span&gt;&lt;/div&gt;
 &lt;br /&gt;
 &lt;p&gt;&lt;span&gt;The example above targets windows account name ID format. Other name ID formats are supported but out of scope of this post. See e.g. &lt;a href=&quot;https://blogs.msdn.microsoft.com/card/2010/02/17/name-identifiers-in-saml-assertions/&quot;&gt;this blog&lt;/a&gt; on how to setup name IDs for persistent and transient formats.&lt;/span&gt;&lt;/p&gt;
 &lt;br /&gt;
 &lt;p&gt;&lt;span&gt;The second rule will map user e-mail to the SAML response. In the &lt;/span&gt;&lt;span style=&quot;font-size: 11pt; font-style: italic&quot;&gt;Add Transform Claim Rule&lt;/span&gt;&lt;span&gt; window, select &lt;/span&gt;&lt;span style=&quot;font-size: 11pt; font-style: italic&quot;&gt;Send LDAP attributes as Claims &lt;/span&gt;&lt;span&gt;rule type. You can add other attributes as needed:&lt;/span&gt;&lt;/p&gt;
 &lt;br /&gt;
 &lt;div style=&quot;margin-bottom: 0pt; margin-top: 0pt; text-align: center;&quot;&gt;
-&lt;span&gt;&lt;img src=&quot;https://www.keycloak.org//resources/images/blog/adfs/6-adfs.png&quot; /&gt;&lt;/span&gt;&lt;/div&gt;
+&lt;span&gt;&lt;img src=&quot;https://www.keycloak.org/resources/images/blog/adfs/6-adfs.png&quot; /&gt;&lt;/span&gt;&lt;/div&gt;
 &lt;br /&gt;
 &lt;p&gt;&lt;span&gt;The third rule would send a group name if the user is member of a named group. Start again in the &lt;/span&gt;&lt;span style=&quot;font-size: 11pt; font-style: italic&quot;&gt;Add Transform Claim Rule&lt;/span&gt;&lt;span&gt; window, and select &lt;/span&gt;&lt;span style=&quot;font-size: 11pt; font-style: italic&quot;&gt;Send Group Membership as a Claim &lt;/span&gt;&lt;span&gt;rule type. Then enter the requested values in the field:&lt;/span&gt;&lt;/p&gt;
 &lt;br /&gt;
 &lt;div style=&quot;margin-bottom: 0pt; margin-top: 0pt; text-align: center;&quot;&gt;
-&lt;span&gt;&lt;img height=&quot;515&quot; src=&quot;https://www.keycloak.org//resources/images/blog/adfs/7-adfs.png&quot; width=&quot;640&quot; /&gt;&lt;/span&gt;&lt;/div&gt;
+&lt;span&gt;&lt;img height=&quot;515&quot; src=&quot;https://www.keycloak.org/resources/images/blog/adfs/7-adfs.png&quot; width=&quot;640&quot; /&gt;&lt;/span&gt;&lt;/div&gt;
 &lt;br /&gt;
 &lt;p&gt;&lt;span&gt;This setup would send an attribute named &lt;/span&gt;&lt;span style=&quot;font-size: 11pt; font-style: italic&quot;&gt;Group &lt;/span&gt;&lt;span&gt;in the SAML assertion with value &lt;/span&gt;&lt;span style=&quot;font-size: 11pt; font-style: italic&quot;&gt;managers&lt;/span&gt;&lt;span&gt; if the authenticated user is member of the &lt;/span&gt;&lt;span style=&quot;font-size: 11pt; font-style: italic&quot;&gt;DOMAIN\Managers&lt;/span&gt;&lt;span&gt; group.&lt;/span&gt;&lt;/p&gt;
 &lt;h2&gt;

--- a/rss.xml
+++ b/rss.xml
@@ -28,7 +28,7 @@
 &lt;/div&gt;
 &lt;/div&gt;
 &lt;h2&gt;All resolved issues&lt;/h2&gt;
-&lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
 
 &lt;h2&gt;Upgrading&lt;/h2&gt;
 &lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org//docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
@@ -58,7 +58,7 @@
 &lt;/div&gt;
 &lt;/div&gt;
 &lt;h2&gt;All resolved issues&lt;/h2&gt;
-&lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
 
 &lt;h2&gt;Upgrading&lt;/h2&gt;
 &lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org//docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
@@ -88,7 +88,7 @@
 &lt;/div&gt;
 &lt;/div&gt;
 &lt;h2&gt;All resolved issues&lt;/h2&gt;
-&lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
 
 &lt;h2&gt;Upgrading&lt;/h2&gt;
 &lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org//docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
@@ -118,7 +118,7 @@
 &lt;/div&gt;
 &lt;/div&gt;
 &lt;h2&gt;All resolved issues&lt;/h2&gt;
-&lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
 
 &lt;h2&gt;Upgrading&lt;/h2&gt;
 &lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org//docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
@@ -345,7 +345,7 @@
 &lt;/div&gt;
 &lt;/div&gt;
 &lt;h2&gt;All resolved issues&lt;/h2&gt;
-&lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
 
 &lt;h2&gt;Upgrading&lt;/h2&gt;
 &lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org//docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
@@ -375,7 +375,7 @@
 &lt;/div&gt;
 &lt;/div&gt;
 &lt;h2&gt;All resolved issues&lt;/h2&gt;
-&lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
 
 &lt;h2&gt;Upgrading&lt;/h2&gt;
 &lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org//docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
@@ -405,7 +405,7 @@
 &lt;/div&gt;
 &lt;/div&gt;
 &lt;h2&gt;All resolved issues&lt;/h2&gt;
-&lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
 
 &lt;h2&gt;Upgrading&lt;/h2&gt;
 &lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org//docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
@@ -457,7 +457,7 @@
 &lt;/div&gt;
 &lt;/div&gt;
 &lt;h2&gt;All resolved issues&lt;/h2&gt;
-&lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
 
 &lt;h2&gt;Upgrading&lt;/h2&gt;
 &lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org//docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
@@ -487,7 +487,7 @@
 &lt;/div&gt;
 &lt;/div&gt;
 &lt;h2&gt;All resolved issues&lt;/h2&gt;
-&lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
 
 &lt;h2&gt;Upgrading&lt;/h2&gt;
 &lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org//docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
@@ -517,7 +517,7 @@
 &lt;/div&gt;
 &lt;/div&gt;
 &lt;h2&gt;All resolved issues&lt;/h2&gt;
-&lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
 
 &lt;h2&gt;Upgrading&lt;/h2&gt;
 &lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org//docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
@@ -634,7 +634,7 @@
 &lt;/div&gt;
 &lt;/div&gt;
 &lt;h2&gt;All resolved issues&lt;/h2&gt;
-&lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
 
 &lt;h2&gt;Upgrading&lt;/h2&gt;
 &lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org//docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
@@ -664,7 +664,7 @@
 &lt;/div&gt;
 &lt;/div&gt;
 &lt;h2&gt;All resolved issues&lt;/h2&gt;
-&lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
 
 &lt;h2&gt;Upgrading&lt;/h2&gt;
 &lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org//docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
@@ -694,7 +694,7 @@
 &lt;/div&gt;
 &lt;/div&gt;
 &lt;h2&gt;All resolved issues&lt;/h2&gt;
-&lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
 
 &lt;h2&gt;Upgrading&lt;/h2&gt;
 &lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org//docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
@@ -724,7 +724,7 @@
 &lt;/div&gt;
 &lt;/div&gt;
 &lt;h2&gt;All resolved issues&lt;/h2&gt;
-&lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
 
 &lt;h2&gt;Upgrading&lt;/h2&gt;
 &lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org//docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
@@ -1321,7 +1321,7 @@ you run the &lt;code&gt;config&lt;/code&gt; command to install your custom provi
 &lt;/div&gt;
 &lt;/div&gt;
 &lt;h2&gt;All resolved issues&lt;/h2&gt;
-&lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
 
 &lt;h2&gt;Upgrading&lt;/h2&gt;
 &lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org//docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
@@ -1351,7 +1351,7 @@ you run the &lt;code&gt;config&lt;/code&gt; command to install your custom provi
 &lt;/div&gt;
 &lt;/div&gt;
 &lt;h2&gt;All resolved issues&lt;/h2&gt;
-&lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
 
 &lt;h2&gt;Upgrading&lt;/h2&gt;
 &lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org//docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
@@ -1464,7 +1464,7 @@ you run the &lt;code&gt;config&lt;/code&gt; command to install your custom provi
 &lt;/div&gt;
 &lt;/div&gt;
 &lt;h2&gt;All resolved issues&lt;/h2&gt;
-&lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
 
 &lt;h2&gt;Upgrading&lt;/h2&gt;
 &lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org//docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
@@ -1555,7 +1555,7 @@ you run the &lt;code&gt;config&lt;/code&gt; command to install your custom provi
 &lt;/div&gt;
 &lt;/div&gt;
 &lt;h2&gt;All resolved issues&lt;/h2&gt;
-&lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
 
 &lt;h2&gt;Upgrading&lt;/h2&gt;
 &lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org//docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
@@ -1585,7 +1585,7 @@ you run the &lt;code&gt;config&lt;/code&gt; command to install your custom provi
 &lt;/div&gt;
 &lt;/div&gt;
 &lt;h2&gt;All resolved issues&lt;/h2&gt;
-&lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
 
 &lt;h2&gt;Upgrading&lt;/h2&gt;
 &lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org//docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
@@ -1615,7 +1615,7 @@ you run the &lt;code&gt;config&lt;/code&gt; command to install your custom provi
 &lt;/div&gt;
 &lt;/div&gt;
 &lt;h2&gt;All resolved issues&lt;/h2&gt;
-&lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
 
 &lt;h2&gt;Upgrading&lt;/h2&gt;
 &lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org//docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
@@ -1645,7 +1645,7 @@ you run the &lt;code&gt;config&lt;/code&gt; command to install your custom provi
 &lt;/div&gt;
 &lt;/div&gt;
 &lt;h2&gt;All resolved issues&lt;/h2&gt;
-&lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
 
 &lt;h2&gt;Upgrading&lt;/h2&gt;
 &lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org//docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
@@ -1675,7 +1675,7 @@ you run the &lt;code&gt;config&lt;/code&gt; command to install your custom provi
 &lt;/div&gt;
 &lt;/div&gt;
 &lt;h2&gt;All resolved issues&lt;/h2&gt;
-&lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
 
 &lt;h2&gt;Upgrading&lt;/h2&gt;
 &lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org//docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
@@ -1725,7 +1725,7 @@ from users of Keycloak in order to make the new admin console as good as it can 
 &lt;/div&gt;
 &lt;/div&gt;
 &lt;h2&gt;All resolved issues&lt;/h2&gt;
-&lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
 
 &lt;h2&gt;Upgrading&lt;/h2&gt;
 &lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org//docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
@@ -1755,7 +1755,7 @@ from users of Keycloak in order to make the new admin console as good as it can 
 &lt;/div&gt;
 &lt;/div&gt;
 &lt;h2&gt;All resolved issues&lt;/h2&gt;
-&lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
 
 &lt;h2&gt;Upgrading&lt;/h2&gt;
 &lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org//docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;
@@ -1785,7 +1785,7 @@ from users of Keycloak in order to make the new admin console as good as it can 
 &lt;/div&gt;
 &lt;/div&gt;
 &lt;h2&gt;All resolved issues&lt;/h2&gt;
-&lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;The full list of resolved issues are available in &lt;a href=&quot;https://github.com/keycloak/keycloak/issues?q=is%3Aissue+user%3Akeycloak+is%3Aclosed+milestone%3A16.1.0&quot;&gt;GitHub Issues&lt;/a&gt;&lt;/p&gt;
 
 &lt;h2&gt;Upgrading&lt;/h2&gt;
 &lt;p&gt;Before you upgrade remember to backup your database and check the &lt;a href=&quot;https://www.keycloak.org//docs/latest/upgrading/index.html&quot;&gt;upgrade guide&lt;/a&gt; for anything that may have changed.&lt;/p&gt;


### PR DESCRIPTION
It seems there is typos in templates used by @keycloak-bot :
- Links to GitHub issues are wrong. https://github.com/issues is used instead of https://github.com/keycloak/keycloak/issues.
- Pathes in https://www.keycloak.org URLs starts with two '/' characters.

I could not find these templates on GitHub but here is a fix for existing pages. 