### PR TITLE
Updating custom header for SEO for generated docs

### DIFF
--- a/.github/java/PatchHtml.java
+++ b/.github/java/PatchHtml.java
@@ -1,0 +1,76 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.regex.Matcher;
+
+/**
+ * Patch HTML files to have a Google Analytics so we can track their use,
+ * robot exclusion for the nightly build,
+ * and a canonical URL to avoid duplicate content at Google that is pointing to the latest build of the file if it exists.
+ */
+public class PatchHtml {
+    public static void main(String[] args) throws IOException {
+        // Either pass the files on the CLI, or stream then in the input.
+        if (args.length > 0) {
+            for (String file : args) {
+                patch(file);
+            }
+        } else {
+            BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
+            while(reader.ready()) {
+                String file = reader.readLine();
+                patch(file);
+            }
+        }
+    }
+
+    private static void patch(String file) throws IOException {
+        String original = Files.readString(Path.of(file));
+        String content = original;
+        content = content.replaceAll("(?ms)<!-- CUSTOM HEADER START.*CUSTOM HEADER END -->\n*", "");
+
+        String canonical = file;
+        canonical = canonical.replaceAll("^docs/[^/]*", "docs/latest");
+        canonical = canonical.replaceAll("^docs-api/[^/]*", "docs-api/latest");
+        if (!canonical.endsWith(".html")) {
+            canonical = "";
+        } else if (Files.exists(Path.of(canonical))) {
+            canonical = "<link rel=\"canonical\" href=\"https://www.keycloak.org/" + canonical + "\">\n";
+        } else if (canonical.endsWith("securing_apps/index.html")) {
+            canonical = "docs/25.0.6/securing_apps/index.html";
+            canonical = "<link rel=\"canonical\" href=\"https://www.keycloak.org/" + canonical + "\">\n";
+        } else {
+            canonical = "";
+        }
+
+        String robots;
+        if (file.contains("nightly")) {
+            robots = "<meta name=\"robots\" content=\"noindex\">\n";
+        } else {
+            robots = "";
+        }
+
+        content = content.replaceAll("<head>", Matcher.quoteReplacement("""
+                <head>
+                <!-- CUSTOM HEADER START -->
+                """ +
+                canonical +
+                robots +
+                """
+                <script async src="https://www.googletagmanager.com/gtag/js?id=G-0J2P9316N6"></script>
+                <script>
+                    window.dataLayer = window.dataLayer || [];
+                    function gtag(){dataLayer.push(arguments);}
+                    gtag('js', new Date());
+                    gtag('config', 'G-0J2P9316N6');
+                </script>
+                <!-- CUSTOM HEADER END -->"""));
+        if (!Objects.equals(original, content)) {
+            System.out.println("Patched " + file);
+            Files.writeString(Path.of(file), content);
+        }
+    }
+}

--- a/.github/workflows/publish-website.yml
+++ b/.github/workflows/publish-website.yml
@@ -1,0 +1,59 @@
+name: Publishing Documentation Site
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    # GitHub will not trigger workflows that originate from pushes with the regular GITHUB_TOKEN,
+    # therefore, name it here explicitly.
+    workflows:
+      - "Update nightly docs"
+    types:
+      - completed
+  push:
+    branches:
+      - main
+
+concurrency:
+  # Only run once for the latest commit per ref and cancel other (previous) runs.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Patch documentation
+        run: |
+          find docs-api -name '*.html' | java .github/java/PatchHtml.java
+          find docs -name '*.html' | java .github/java/PatchHtml.java
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+
+  github-pages:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    name: GitHub Pages
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This adds a script to add the right headers to our HTML pages.

This should prevent indexing of nightly docs, and asks google to always index the "latest" version of the file if that one should exist. I will also work for the Javadocs.

You find a successful run:
https://github.com/ahus1/keycloak.github.io/actions/runs/12987956397/job/36217897216

